### PR TITLE
change base image to go-toolset:1.24.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-# Build Stage: using Go 1.24.1 image
-FROM quay.io/projectquay/golang:1.24 AS builder
+# Build Stage: using Go 1.24 image
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+USER root 
 
 # Install build tools
 RUN dnf install -y gcc-c++ libstdc++ libstdc++-devel clang && dnf clean all


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use UBI9/GO-TOOLSET image as builder.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image used for building the application to a Red Hat UBI 9-based image with Go 1.24.4.
  * Adjusted build configuration to run as the root user during the build stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->