### PR TITLE
Since we use a UBI 9 base image in ODH, install the EPEL 9 repository instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ ARG TARGETARCH
 USER root 
 
 # Install build tools
-# The builder is based on UBI8, so we need epel-release-8.
-RUN dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm' && \
+RUN dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm' && \
     dnf install -y gcc-c++ libstdc++ libstdc++-devel clang zeromq-devel pkgconfig && \
     dnf clean all
 


### PR DESCRIPTION
## Description
install the EPEL 9 repository to match the base image ubi 9 environment 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build environment to align with the runtime image, improving build consistency and reducing potential mismatches during development and deployment.
  * No changes to application behavior or features.

* **Notes**
  * This update affects the build process only; end users should not experience any functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->