### PR TITLE
[Cherry pick] Since we use a UBI 9 base image in ODH, install the EPEL 9 repository instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ ARG TARGETARCH
 USER root 
 
 # Install build tools
-# The builder is based on UBI8, so we need epel-release-8.
-RUN dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm' && \
+RUN dnf install -y 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm' && \
     dnf install -y gcc-c++ libstdc++ libstdc++-devel clang zeromq-devel pkgconfig && \
     dnf clean all
 


### PR DESCRIPTION
## Description
cherry pick of https://github.com/opendatahub-io/llm-d-inference-scheduler/pull/21 