### PR TITLE
fix: CVE-2025-61729 - pin builder image to go-toolset:1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d/llm-d-inference-scheduler
 
-go 1.25.0
+go 1.25.7
 
 toolchain go1.25.8
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/llm-d/llm-d-inference-scheduler
 
-go 1.25.7
+go 1.25.0
+
+toolchain go1.25.8
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Update go.mod to use go 1.25.0 / toolchain go1.25.8 pattern and pin Dockerfile.sidecar.konflux builder image to go-toolset:1.25.8 with digest to ensure the fix for CVE-2025-61729 (GO-2025-4155) is included (requires >= 1.25.5).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain configuration to standardize build behavior and ensure consistent tooling across environments, preventing mismatches during builds and local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->