### PR TITLE
fix(tekton): use v0.7.1 image tag on release branch

### DIFF
--- a/.tekton/llm-d-inference-scheduler-push.yaml
+++ b/.tekton/llm-d-inference-scheduler-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "release-v0.7.1"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/llm-d-inference-scheduler:odh-stable
+    value: quay.io/opendatahub/llm-d-inference-scheduler:v0.7.1
   - name: dockerfile
     value: Dockerfile.epp
   - name: path-context

--- a/.tekton/odh-llm-d-routing-sidecar-push.yaml
+++ b/.tekton/odh-llm-d-routing-sidecar-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "release-v0.7.1"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/llm-d-routing-sidecar:odh-stable
+    value: quay.io/opendatahub/llm-d-routing-sidecar:v0.7.1
   - name: dockerfile
     value: Dockerfile.sidecar
   pipelineRef:


### PR DESCRIPTION
## Summary
- Update `output-image` tag from `:odh-stable` to `:v0.7.1` in both push pipelines so release builds don't overwrite main's image tag
- Update CEL expression `target_branch` from `"main"` to `"release-v0.7.1"` so pipelines actually trigger on this branch
- Aligns with how [llm-d-kv-cache](https://github.com/opendatahub-io/llm-d-kv-cache/blob/release-v0.7.1/.tekton/llm-d-kv-cache-release-push.yaml) is configured on `release-v0.7.1`

## Test plan
- [ ] Verify pipeline triggers on merge to `release-v0.7.1`
- [ ] Verify built images are tagged `:v0.7.1` on quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)