### PR TITLE
feat: add customized tekton pipeline to build image from tag

### DIFF
--- a/.tekton/odh-llm-d-router-disagg-sidecar-tag.yaml
+++ b/.tekton/odh-llm-d-router-disagg-sidecar-tag.yaml
@@ -1,0 +1,46 @@
+# This is for the team internal build image for Kserve to integrate
+# Nothing to do with DevOps konflux, but reuse the same setup
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-router?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("refs/tags/v")
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-router-disagg-sidecar-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-router-disagg-sidecar-on-tag
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-router-disagg-sidecar:{{git_tag}}
+  - name: dockerfile
+    value: Dockerfile.sidecar.konflux
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-router-disagg-sidecar-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/odh-llm-d-router-endpoint-picker-tag.yaml
+++ b/.tekton/odh-llm-d-router-endpoint-picker-tag.yaml
@@ -1,0 +1,46 @@
+# This is for the team internal build image for Kserve to integrate
+# Nothing to do with DevOps konflux, but reuse the same setup
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-router?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("refs/tags/v")
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-router-endpoint-picker-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-router-endpoint-picker-on-tag
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-router-endpoint-picker:{{git_tag}}
+  - name: dockerfile
+    value: Dockerfile.epp.konflux
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-router-endpoint-picker-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
# Notes
- image should store in quay.io/opendatahub and tagged with the same git tag: vx.y.z matching upstream llm-d-router release
- to retrigger build in case build failure, force push tag, on-command wont work in this case without specify tag name




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build pipeline configurations to enable container image builds and publishing triggered on version tag releases, improving internal build automation infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->