### PR TITLE
[sync] upstream llm-d/llm-d-router c82561bf [2026-07-18]

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -33,6 +33,10 @@ inputs:
     required: false
     description: Git commit SHA to embed via COMMIT_SHA build arg
     default: ''
+  additional-tags:
+    required: false
+    description: Additional image tags to push
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -58,6 +62,7 @@ runs:
           ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }}
           ${{ inputs.push == 'true' && inputs.prerelease != 'true' && format('{0}/{1}:latest', inputs.registry, inputs.image-name) || '' }}
           ${{ inputs.commit-sha != '' && format('{0}/{1}:{2}', inputs.registry, inputs.image-name, inputs.commit-sha) || '' }}
+          ${{ inputs.additional-tags }}
         build-args: |
           LDFLAGS=-s -w
           COMMIT_SHA=${{ inputs.commit-sha || 'unknown' }}

--- a/.github/actions/helm-build-and-push/action.yml
+++ b/.github/actions/helm-build-and-push/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ''
   epp_image_repository:
-    description: 'EPP image repository name (e.g. llm-d-router-endpoint-picker or llm-d-router-endpoint-picker-dev)'
+    description: 'EPP image repository name (e.g. llm-d-router-endpoint-picker)'
     required: false
     default: 'llm-d-router-endpoint-picker'
 runs:

--- a/.github/workflows/ci-build-images.yaml
+++ b/.github/workflows/ci-build-images.yaml
@@ -19,6 +19,14 @@ on:
         required: false
         type: string
         default: ''
+      epp-additional-tags:
+        required: false
+        type: string
+        default: ''
+      sidecar-additional-tags:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -60,6 +68,7 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           commit-sha: ${{ github.sha }}
           push: 'true'
+          additional-tags: ${{ inputs.epp-additional-tags }}
 
   build-sidecar:
     runs-on: ubuntu-latest
@@ -93,6 +102,7 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           commit-sha: ${{ github.sha }}
           push: 'true'
+          additional-tags: ${{ inputs.sidecar-additional-tags }}
 
   push-helm-charts:
     needs: [build-epp, build-sidecar]

--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -19,6 +19,8 @@ jobs:
     outputs:
       epp_name: ${{ steps.version.outputs.epp_name }}
       sidecar_name: ${{ steps.version.outputs.sidecar_name }}
+      epp_base_name: ${{ steps.version.outputs.epp_base_name }}
+      sidecar_base_name: ${{ steps.version.outputs.sidecar_base_name }}
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Set image names
@@ -27,6 +29,8 @@ jobs:
           repo="${GITHUB_REPOSITORY##*/}"
           echo "epp_name=${repo}-endpoint-picker-dev" >> "$GITHUB_OUTPUT"
           echo "sidecar_name=${repo}-disagg-sidecar-dev" >> "$GITHUB_OUTPUT"
+          echo "epp_base_name=${repo}-endpoint-picker" >> "$GITHUB_OUTPUT"
+          echo "sidecar_base_name=${repo}-disagg-sidecar" >> "$GITHUB_OUTPUT"
 
       - name: Set branch name as tag
         id: tag
@@ -42,5 +46,7 @@ jobs:
       sidecar-image-name: ${{ needs.set-params.outputs.sidecar_name }}
       tag: ${{ needs.set-params.outputs.tag }}
       prerelease: true
-      chart-suffix: "-dev"
+      chart-suffix: ""
+      epp-additional-tags: ghcr.io/llm-d/${{ needs.set-params.outputs.epp_base_name }}:main
+      sidecar-additional-tags: ghcr.io/llm-d/${{ needs.set-params.outputs.sidecar_base_name }}:main
 

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -1,3 +1,6 @@
+# Matrix jobs (e2e-image-common, e2e-image-router, e2e-router) are each
+# followed by a *-status job that aggregates their result, since GitHub
+# required status checks cannot reference individual matrix legs.
 name: CI - Test
 
 on:
@@ -256,6 +259,19 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  e2e-image-common-status:
+    needs: e2e-image-common
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-image-common result
+        run: |
+          result="${{ needs.e2e-image-common.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-image-common failed for at least one matrix image"
+            exit 1
+          fi
+
   e2e-image-router:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.src == 'true' }}
@@ -305,6 +321,19 @@ jobs:
           path: ${{ runner.temp }}/${{ matrix.image.archive }}.tar
           retention-days: 1
           compression-level: 0
+
+  e2e-image-router-status:
+    needs: e2e-image-router
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-image-router result
+        run: |
+          result="${{ needs.e2e-image-router.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-image-router failed for at least one matrix image"
+            exit 1
+          fi
 
   e2e-router:
     needs:
@@ -393,3 +422,16 @@ jobs:
           PULL_VLLM_RENDER_IMAGE: "false"
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: make test-e2e-run
+
+  e2e-router-status:
+    needs: e2e-router
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e-router result
+        run: |
+          result="${{ needs.e2e-router.result }}"
+          if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+            echo "::error::e2e-router failed for at least one matrix suite"
+            exit 1
+          fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,6 +44,10 @@
 # Tokenization
 /pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer/          @vMaroon @liu-cong @sagearc @llm-d/router-maintainers
 
+# KV-cache subsystem — indexer, KV-block index, KV-events
+/pkg/kvcache/                                                              @vMaroon @liu-cong @hyeongyun0916 @yankay @sagearc @llm-d/router-maintainers
+/pkg/kvevents/                                                             @vMaroon @liu-cong @hyeongyun0916 @yankay @sagearc @llm-d/router-maintainers
+
 # Request handling
 /pkg/epp/framework/interface/requesthandling/                             @zetxqx @llm-d/router-maintainers
 /pkg/epp/framework/plugins/requesthandling/                               @zetxqx @llm-d/router-maintainers

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -101,6 +101,7 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmgrpc"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/bylabel"
+	endpointattributefilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/endpointattribute"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/prefixcacheaffinity"
 	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sloheadroomtier"
@@ -548,6 +549,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(bylabel.EncodeRoleType, bylabel.EncodeRoleFactory)
 	fwkplugin.Register(bylabel.DecodeRoleType, bylabel.DecodeRoleFactory)
 	fwkplugin.Register(bylabel.PrefillRoleType, bylabel.PrefillRoleFactory)
+	fwkplugin.Register(endpointattributefilter.EndpointAttributeFilterType, endpointattributefilter.EndpointAttributeFilterFactory)
 	fwkplugin.Register(sessionaffinityfilter.SessionAffinityType, sessionaffinityfilter.Factory)
 
 	// dataparallel profile handler

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -332,6 +332,7 @@ func (r *Runner) runWithGracefulShutdown(ctx context.Context, mgr ctrl.Manager, 
 //
 // The returned Datastore is **only** meant to be used in the integration test.
 // Optional managerOverrides are applied to the controller manager options before creation.
+
 func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Options, managerOverrides []func(*ctrl.Options)) (ctrl.Manager, datastore.Datastore, error) {
 	rawConfig, err := r.parseConfigurationPhaseOne(ctx, opts)
 	if err != nil {
@@ -386,6 +387,10 @@ func (r *Runner) setup(ctx context.Context, cfg *rest.Config, opts *runserver.Op
 
 			return nil
 		}(),
+	}
+
+	if err := runserver.ConfigureMetricsTLS(opts, &metricsServerOptions); err != nil {
+		return nil, nil, err
 	}
 
 	isLeader := &atomic.Bool{}

--- a/cmd/epp/runner/runner.go
+++ b/cmd/epp/runner/runner.go
@@ -91,8 +91,8 @@ import (
 	latencyproducer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/predictedlatency"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/sessionid"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer"
-	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/preadmitter/agentidentity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestattributereporter"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
 	testresponsereceived "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/test/responsereceived"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/anthropic"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
@@ -642,7 +642,7 @@ func (r *Runner) registerInTreePlugins() {
 	fwkplugin.Register(utilization.UtilizationDetectorType, utilization.UtilizationDetectorFactory)
 	// register discovery plugins
 	fwkplugin.Register(discoveryfile.PluginType, discoveryfile.Factory)
-	// register pre-admission processor plugins
+	// register request header processor plugins
 	fwkplugin.Register(agentidentity.PluginType, agentidentity.PluginFactory)
 }
 

--- a/config/charts/README.md
+++ b/config/charts/README.md
@@ -119,7 +119,7 @@ Core settings for the Endpoint Picker Proxy (EPP) container and pod, including s
 | `router.epp.replicas` | Number of EPP replicas. Set > 1 to enable multi-replica EPP. | `1` |
 | `router.epp.extProcPort` | Port EPP uses for external processing gRPC communication. | `9002` |
 | `router.epp.image.registry` | EPP container image registry. | `ghcr.io/llm-d` |
-| `router.epp.image.repository` | EPP container image repository. | `llm-d-router-endpoint-picker-dev` |
+| `router.epp.image.repository` | EPP container image repository. | `llm-d-router-endpoint-picker` |
 | `router.epp.image.tag` | EPP container image tag. | `main` |
 | `router.epp.image.pullPolicy` | EPP container image pull policy. | `Always` |
 | `router.epp.env` | Extra environment variables for EPP container. | `[]` |

--- a/config/charts/routerlib/values.yaml
+++ b/config/charts/routerlib/values.yaml
@@ -7,7 +7,7 @@ epp:
   replicas: 1
   image:
     registry: ghcr.io/llm-d
-    repository: llm-d-router-endpoint-picker-dev
+    repository: llm-d-router-endpoint-picker
     tag: main
     pullPolicy: Always
   extProcPort: 9002

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -113,6 +113,29 @@ Exposed when the `flowControl` feature gate is enabled. All carry the `llm_d_epp
 *   **Description:** Current saturation level of the inference pool (0.0 = empty, 1.0 = fully saturated).
 *   **Usage:** When saturation reaches the usage limit threshold, the dispatch cycle skips dispatching and requests remain queued. Sustained 1.0 indicates all backends are at capacity.
 
+### `flow_control_requests_total`
+
+*   **Type:** Counter
+*   **Labels:**
+    *   `outcome`: string — the terminal outcome of the request. One of:
+        *   `Dispatched` — request was forwarded to a backend
+        *   `RejectedCapacity` — request was rejected because the queue was at capacity
+        *   `RejectedNoEndpoints` — request was rejected at the capacity boundary while the candidate pool had no endpoints (surfaces as HTTP 503 rather than 429)
+        *   `RejectedOther` — request was rejected for another reason (e.g., controller shutdown)
+        *   `EvictedTTL` — request exceeded its time-to-live while waiting in the queue
+        *   `EvictedContextCancelled` — client disconnected before the request was dispatched
+        *   `EvictedOther` — request was evicted for another reason
+    *   `priority`: string (the priority band, e.g., `"0"`, `"10"`)
+    *   `inference_pool`: string
+*   **Release Stage:** ALPHA
+*   **Description:** Total number of requests processed by the Flow Control layer, incremented once per request after its terminal outcome is determined.
+*   **Usage:** Provides a direct signal for rejection and eviction rates without log parsing. Unlike `flow_control_request_queue_duration_seconds_count`, this counter also captures controller-level early rejections where no queue item is created (e.g., rejection during controller shutdown), covering cases the histogram misses.
+*   **Actionability:**
+    *   A rising rate of `outcome="RejectedCapacity"` indicates the queue capacity limits are too tight or backends are persistently saturated — consider tuning `maxBytes`/`maxRequests` or scaling backends.
+    *   A rising rate of `outcome="RejectedNoEndpoints"` indicates the inference pool has scaled to zero or all endpoints are unregistered — investigate pool health and scaling configuration.
+    *   A rising rate of `outcome="EvictedTTL"` indicates requests are waiting longer than their TTL allows — investigate backend throughput or tighten admission.
+    *   `outcome="Dispatched"` is the healthy baseline; compare it against total request rate to derive the acceptance ratio.
+
 
 ## Opt-in ext_proc Stream Metrics
 

--- a/pkg/epp/framework/interface/requestcontrol/plugins.go
+++ b/pkg/epp/framework/interface/requestcontrol/plugins.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	PreAdmissionExtensionPoint      = "PreAdmission"
+	RequestHeaderExtensionPoint     = "RequestHeader"
 	AdmissionExtensionPoint         = "Admission"
 	DataProducerExtensionPoint      = "DataProducer"
 	PreRequestExtensionPoint        = "PreRequest"
@@ -92,9 +92,10 @@ type Admitter interface {
 	Admit(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error
 }
 
-// PreAdmitter runs after InferenceRequest creation but before admission control.
-// It can mutate InferenceRequest fields such as FairnessID and Headers.
-type PreAdmitter interface {
+// RequestHeaderProcessor runs after InferenceRequest creation but before admission control.
+// It processes request metadata (headers, path, method) to attach attributes to the request
+// via request.PutAttribute().
+type RequestHeaderProcessor interface {
 	plugin.Plugin
-	PreAdmit(ctx context.Context, request *fwksched.InferenceRequest) error
+	RequestHeader(ctx context.Context, request *fwksched.InferenceRequest) error
 }

--- a/pkg/epp/framework/interface/requesthandling/plugins.go
+++ b/pkg/epp/framework/interface/requesthandling/plugins.go
@@ -52,6 +52,13 @@ type Parser interface {
 	Claims() Claims
 }
 
+// ModelNameRewriter is implemented by parsers whose forwarded body can carry a model name.
+type ModelNameRewriter interface {
+	// RewriteModelName writes model into the payload and returns it. Taking and
+	// returning a MarshalablePayload guarantees the result is repackageable.
+	RewriteModelName(payload MarshalablePayload, model string) (MarshalablePayload, error)
+}
+
 // Claims defines the matching criteria for a parser.
 type Claims struct {
 	Paths     []string         // path patterns this parser claims (e.g., "chat/completions")

--- a/pkg/epp/framework/interface/requesthandling/types.go
+++ b/pkg/epp/framework/interface/requesthandling/types.go
@@ -50,12 +50,26 @@ type RequestPayload interface {
 	AsMap() (PayloadMap, bool)
 }
 
+// Marshaler is implemented by payloads that serialize themselves back to the bytes
+// forwarded downstream. Payloads that do not are forwarded unchanged.
+type Marshaler interface {
+	Marshal() ([]byte, error)
+}
+
+// MarshalablePayload is a RequestPayload that can serialize itself back to bytes.
+// Only such payloads are worth mutating, since only they are re-marshaled on repackage.
+type MarshalablePayload interface {
+	RequestPayload
+	Marshaler
+}
+
 // PayloadMap represents a JSON request body unmarshaled into a map.
 type PayloadMap map[string]any
 
 func (p PayloadMap) isRequestPayload()         {}
 func (p PayloadMap) IsParsed() bool            { return true }
 func (p PayloadMap) AsMap() (PayloadMap, bool) { return p, p != nil }
+func (p PayloadMap) Marshal() ([]byte, error)  { return json.Marshal(map[string]any(p)) }
 
 // PayloadProto represents a gRPC request body unmarshaled into a proto.Message.
 type PayloadProto struct {
@@ -112,6 +126,10 @@ type InferenceRequestBody struct {
 	// It is nil when the client did not specify a cap. Consumers such as output
 	// token estimators use it as an upper bound. Derived, not round-tripped.
 	MaxOutputTokens *int64 `json:"-"`
+
+	// Model is the incoming client-facing model name extracted by the parser, empty
+	// if absent. Not round-tripped; the forwarded model lives in Payload.
+	Model string `json:"-"`
 }
 
 // MaxOutputTokensFromPayload returns the client-requested output-token cap read

--- a/pkg/epp/framework/plugins/datalayer/source/http/client.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/client.go
@@ -59,6 +59,7 @@ var (
 	baseTransport = &http.Transport{
 		MaxIdleConns:        maxIdleConnections,
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
+		IdleConnTimeout:     maxIdleTime,
 		// TODO: set additional timeouts, transport options, etc.
 	}
 )

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource.go
@@ -19,11 +19,13 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"runtime/debug"
 	"slices"
@@ -60,8 +62,23 @@ type HTTPDataSource[T any] struct {
 	exts []fwkdl.PollingExtractor[T]
 }
 
-// NewHTTPDataSource constructs a typed polling dispatcher.
-func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
+// TLSOptions configures the https transport. The zero value verifies the target
+// against the system CA pool with no client certificate.
+type TLSOptions struct {
+	// SkipVerify disables verification of the target's server certificate.
+	SkipVerify bool
+	// CACertPath is a PEM CA bundle used to verify the target instead of the
+	// system pool. Ignored when SkipVerify is set.
+	CACertPath string
+	// ClientCertPath and ClientKeyPath present a client certificate for mTLS.
+	// Both must be set together.
+	ClientCertPath string
+	ClientKeyPath  string
+}
+
+// NewHTTPDataSource constructs a typed polling dispatcher. For https, tlsOpts configures
+// server verification (CACertPath) and optional mTLS (ClientCertPath/ClientKeyPath).
+func NewHTTPDataSource[T any](scheme, path string, tlsOpts TLSOptions,
 	pluginType, pluginName string, parser func(io.Reader) (T, error)) (*HTTPDataSource[T], error) {
 	if scheme != "http" && scheme != "https" {
 		return nil, fmt.Errorf("unsupported scheme: %s", scheme)
@@ -73,8 +90,12 @@ func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
 		},
 	}
 	if scheme == "https" {
+		tlsCfg, err := tlsClientConfig(tlsOpts)
+		if err != nil {
+			return nil, err
+		}
 		httpsTransport := baseTransport.Clone()
-		httpsTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipCertVerification}
+		httpsTransport.TLSClientConfig = tlsCfg
 		cl.Transport = httpsTransport
 	}
 	return &HTTPDataSource[T]{
@@ -84,6 +105,46 @@ func NewHTTPDataSource[T any](scheme, path string, skipCertVerification bool,
 		client:    cl,
 		parser:    parser,
 	}, nil
+}
+
+var (
+	ErrReadCACert     = errors.New("reading CA cert")
+	ErrNoValidCACerts = errors.New("no valid CA certs")
+	ErrLoadClientCert = errors.New("loading client cert")
+)
+
+// caCertPool loads a PEM CA bundle for TLS verification.
+func caCertPool(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w %s: %w", ErrReadCACert, path, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("%w in %s", ErrNoValidCACerts, path)
+	}
+	return pool, nil
+}
+
+// tlsClientConfig builds a tls.Config: server verification via CACertPath (or the
+// system pool), plus an mTLS client certificate when ClientCertPath is set.
+func tlsClientConfig(opts TLSOptions) (*tls.Config, error) {
+	cfg := &tls.Config{InsecureSkipVerify: opts.SkipVerify}
+	if !opts.SkipVerify && opts.CACertPath != "" {
+		pool, err := caCertPool(opts.CACertPath)
+		if err != nil {
+			return nil, err
+		}
+		cfg.RootCAs = pool
+	}
+	if opts.ClientCertPath != "" || opts.ClientKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(opts.ClientCertPath, opts.ClientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrLoadClientCert, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	return cfg, nil
 }
 
 func (s *HTTPDataSource[T]) TypedName() fwkplugin.TypedName { return s.typedName }

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_catls_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCACert writes a self-signed CA PEM and returns its path.
+func writeCACert(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	return path
+}
+
+func TestCACertPool(t *testing.T) {
+	badPEM := filepath.Join(t.TempDir(), "bad.pem")
+	require.NoError(t, os.WriteFile(badPEM, []byte("not a certificate"), 0o600))
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr error
+	}{
+		{name: "valid CA bundle", path: writeCACert(t)},
+		{name: "missing file", path: filepath.Join(t.TempDir(), "nope.pem"), wantErr: ErrReadCACert},
+		{name: "invalid PEM", path: badPEM, wantErr: ErrNoValidCACerts},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, err := caCertPool(tt.path)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, pool)
+		})
+	}
+}
+
+func TestNewHTTPDataSource_CACertPath(t *testing.T) {
+	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
+
+	tests := []struct {
+		name       string
+		caCertPath string
+		wantErr    error
+		wantRootCA bool
+	}{
+		{name: "valid CA sets RootCAs", caCertPath: writeCACert(t), wantRootCA: true},
+		{name: "empty CA uses system pool", caCertPath: "", wantRootCA: false},
+		{name: "bad CA path errors", caCertPath: "/nonexistent/ca.pem", wantErr: ErrReadCACert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := NewHTTPDataSource[any]("https", "/metrics", TLSOptions{CACertPath: tt.caCertPath}, "test-type", "ds", parser)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			cl, ok := ds.client.(*client)
+			require.True(t, ok)
+			tr, ok := cl.Transport.(*http.Transport)
+			require.True(t, ok)
+			assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
+			if tt.wantRootCA {
+				assert.NotNil(t, tr.TLSClientConfig.RootCAs)
+			} else {
+				assert.Nil(t, tr.TLSClientConfig.RootCAs)
+			}
+		})
+	}
+}
+
+// writeCertKey writes a self-signed cert and its key as separate PEMs; returns their paths.
+func writeCertKey(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+	return certPath, keyPath
+}
+
+func TestNewHTTPDataSource_ClientCert(t *testing.T) {
+	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
+	certPath, keyPath := writeCertKey(t)
+
+	tests := []struct {
+		name           string
+		opts           TLSOptions
+		wantErr        error
+		wantClientCert bool
+	}{
+		{name: "valid client cert sets Certificates", opts: TLSOptions{ClientCertPath: certPath, ClientKeyPath: keyPath}, wantClientCert: true},
+		{name: "no client cert", opts: TLSOptions{}, wantClientCert: false},
+		{name: "bad client cert path errors", opts: TLSOptions{ClientCertPath: "/nonexistent/cert.pem", ClientKeyPath: "/nonexistent/key.pem"}, wantErr: ErrLoadClientCert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := NewHTTPDataSource[any]("https", "/metrics", tt.opts, "test-type", "ds", parser)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			cl, ok := ds.client.(*client)
+			require.True(t, ok)
+			tr, ok := cl.Transport.(*http.Transport)
+			require.True(t, ok)
+			if tt.wantClientCert {
+				assert.Len(t, tr.TLSClientConfig.Certificates, 1)
+			} else {
+				assert.Empty(t, tr.TLSClientConfig.Certificates)
+			}
+		})
+	}
+}

--- a/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/http/datasource_isolation_test.go
@@ -28,11 +28,11 @@ func TestHTTPDataSource_ClientIsolation(t *testing.T) {
 	parser := func(r io.Reader) (any, error) { return struct{}{}, nil }
 
 	// Create first HTTPS datasource, insecureSkipVerify = false
-	ds1, err := NewHTTPDataSource[any]("https", "/metrics", false, "test-type", "ds1", parser)
+	ds1, err := NewHTTPDataSource[any]("https", "/metrics", TLSOptions{}, "test-type", "ds1", parser)
 	assert.NoError(t, err)
 
 	// Create second HTTPS datasource, insecureSkipVerify = true
-	ds2, err := NewHTTPDataSource[any]("https", "/metrics", true, "test-type", "ds2", parser)
+	ds2, err := NewHTTPDataSource[any]("https", "/metrics", TLSOptions{SkipVerify: true}, "test-type", "ds2", parser)
 	assert.NoError(t, err)
 
 	// Verify ds1 uses isolated transport config

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/README.md
@@ -24,6 +24,8 @@ The plugin config supports:
 -   `scheme` (default "http"): The protocol scheme to use for metrics retrieval.
 -   `path` (default "/metrics"): The URL path to use for metrics retrieval.
 -   `insecureSkipVerify` (default true): Whether to skip TLS certificate verification when using the "https" scheme.
+-   `caCertPath`: PEM CA bundle to verify the target's server cert.
+-   `clientCertPath` / `clientKeyPath`: client certificate for mTLS. Set both together.
 
 ### Example Configuration
 

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource.go
@@ -45,13 +45,19 @@ type metricsDatasourceParams struct {
 	Path string `json:"path"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+	// CACertPath is an optional PEM CA bundle to verify the scrape target cert.
+	CACertPath string `json:"caCertPath"`
+	// ClientCertPath and ClientKeyPath present a client certificate for mTLS, so the scrape
+	// target authenticates this scraper by certificate instead of a bearer token. Both set together.
+	ClientCertPath string `json:"clientCertPath"`
+	ClientKeyPath  string `json:"clientKeyPath"`
 }
 
 // NewHTTPMetricsDataSource constructs a MetricsDataSource with the given scheme and path.
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPMetricsDataSource(scheme, path, name string) (*http.HTTPDataSource[PrometheusMetricMap], error) {
-	return http.NewHTTPDataSource(scheme, path, defaultMetricsInsecureSkipVerify,
+	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultMetricsInsecureSkipVerify},
 		MetricsDataSourceType, name, parseMetrics)
 }
 
@@ -66,7 +72,13 @@ func MetricsDataSourceFactory(name string, parameters *json.Decoder, handle fwkp
 		}
 	}
 
-	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify,
+	return http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
+		http.TLSOptions{
+			SkipVerify:     cfg.InsecureSkipVerify,
+			CACertPath:     cfg.CACertPath,
+			ClientCertPath: cfg.ClientCertPath,
+			ClientKeyPath:  cfg.ClientKeyPath,
+		},
 		MetricsDataSourceType, name, parseMetrics)
 }
 

--- a/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/metrics/datasource_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package metrics
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,12 +29,36 @@ import (
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
 
+func TestMetricsDataSourceFactory_TLS(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  string
+		wantErr error
+	}{
+		{name: "https no certs", params: `{"scheme":"https"}`},
+		{name: "client cert wired to loader", params: `{"scheme":"https","clientCertPath":"/nope/c.pem","clientKeyPath":"/nope/k.pem"}`, wantErr: http.ErrLoadClientCert},
+		{name: "ca path wired to loader", params: `{"scheme":"https","insecureSkipVerify":false,"caCertPath":"/nope/ca.pem"}`, wantErr: http.ErrReadCACert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := MetricsDataSourceFactory("m", json.NewDecoder(bytes.NewBufferString(tt.params)), nil)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, ds)
+		})
+	}
+}
+
 func TestDatasource(t *testing.T) {
-	_, err := http.NewHTTPDataSource("invalid", "/metrics", true, MetricsDataSourceType,
+	_, err := http.NewHTTPDataSource("invalid", "/metrics", http.TLSOptions{SkipVerify: true}, MetricsDataSourceType,
 		"metrics-data-source", parseMetrics)
 	assert.NotNil(t, err, "expected to fail with invalid scheme")
 
-	source, err := http.NewHTTPDataSource("https", "/metrics", true, MetricsDataSourceType,
+	source, err := http.NewHTTPDataSource("https", "/metrics", http.TLSOptions{SkipVerify: true}, MetricsDataSourceType,
 		"metrics-data-source", parseMetrics)
 	assert.Nil(t, err, "failed to create HTTP datasource")
 

--- a/pkg/epp/framework/plugins/datalayer/source/models/README.md
+++ b/pkg/epp/framework/plugins/datalayer/source/models/README.md
@@ -20,6 +20,8 @@ The Models Data Source polls inference server pods for model information and pas
 - `scheme` (string, optional, default: `"http"`): Protocol scheme: `"http"` or `"https"`.
 - `path` (string, optional, default: `"/v1/models"`): URL path for the models API endpoint.
 - `insecureSkipVerify` (bool, optional, default: `true`): Skip TLS certificate verification.
+- `caCertPath` (string, optional): PEM CA bundle to verify the target's server cert.
+- `clientCertPath` / `clientKeyPath` (string, optional): client certificate for mTLS. Set both together.
 
 ```yaml
 - type: models-data-source

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource.go
@@ -28,13 +28,19 @@ type modelsDatasourceParams struct {
 	Path string `json:"path"`
 	// InsecureSkipVerify defines whether model server certificate should be verified or not.
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+	// CACertPath is an optional PEM CA bundle to verify the scrape target cert.
+	CACertPath string `json:"caCertPath"`
+	// ClientCertPath and ClientKeyPath present a client certificate for mTLS, so the scrape
+	// target can require+verify the client.
+	ClientCertPath string `json:"clientCertPath"`
+	ClientKeyPath  string `json:"clientKeyPath"`
 }
 
 // NewHTTPModelsDataSource constructs a ModelsDataSource with the given scheme and path.
 // InsecureSkipVerify defaults to true (matching the factory default).
 // Use this function directly in tests to bypass JSON parameter marshaling.
 func NewHTTPModelsDataSource(scheme, path, name string) (*http.HTTPDataSource[*extmodels.ModelResponse], error) {
-	return http.NewHTTPDataSource(scheme, path, defaultModelsInsecureSkipVerify,
+	return http.NewHTTPDataSource(scheme, path, http.TLSOptions{SkipVerify: defaultModelsInsecureSkipVerify},
 		ModelsDataSourceType, name, parseModels)
 }
 
@@ -51,7 +57,13 @@ func ModelDataSourceFactory(name string, parameters *json.Decoder, _ plugin.Hand
 		return nil, fmt.Errorf("unsupported scheme: %s", cfg.Scheme)
 	}
 
-	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path, cfg.InsecureSkipVerify,
+	ds, err := http.NewHTTPDataSource(cfg.Scheme, cfg.Path,
+		http.TLSOptions{
+			SkipVerify:     cfg.InsecureSkipVerify,
+			CACertPath:     cfg.CACertPath,
+			ClientCertPath: cfg.ClientCertPath,
+			ClientKeyPath:  cfg.ClientKeyPath,
+		},
 		ModelsDataSourceType, name, parseModels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP data source: %w", err)

--- a/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
+++ b/pkg/epp/framework/plugins/datalayer/source/models/datasource_test.go
@@ -15,7 +15,32 @@ import (
 	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
 	fwkplugin "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
 	extmodels "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/extractor/models"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/source/http"
 )
+
+func TestModelDataSourceFactory_TLS(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  string
+		wantErr error
+	}{
+		{name: "https no certs", params: `{"scheme":"https"}`},
+		{name: "client cert wired to loader", params: `{"scheme":"https","clientCertPath":"/nope/c.pem","clientKeyPath":"/nope/k.pem"}`, wantErr: http.ErrLoadClientCert},
+		{name: "ca path wired to loader", params: `{"scheme":"https","insecureSkipVerify":false,"caCertPath":"/nope/ca.pem"}`, wantErr: http.ErrReadCACert},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := ModelDataSourceFactory("m", fwkplugin.StrictDecoder(json.RawMessage(tt.params)), nil)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, ds)
+		})
+	}
+}
 
 func TestDatasource(t *testing.T) {
 	srcPlugin, err := ModelDataSourceFactory("models-data-source",

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin.go
@@ -72,6 +72,7 @@ var (
 	_ flowcontrol.FairnessPolicy  = &ProgramAwarePlugin{}
 	_ fwkrc.PreRequest            = &ProgramAwarePlugin{}
 	_ fwkrc.ResponseBodyProcessor = &ProgramAwarePlugin{}
+	_ plugin.StateDumper          = &ProgramAwarePlugin{}
 )
 
 //nolint:revive // factory name matches sibling fairness plugins.
@@ -118,6 +119,45 @@ type ProgramAwarePlugin struct {
 
 func (p *ProgramAwarePlugin) TypedName() plugin.TypedName {
 	return plugin.TypedName{Type: ProgramAwarePluginType, Name: p.name}
+}
+
+// fairnessDumpState is the sanitized snapshot returned by DumpState. Program IDs
+// come from a user-controlled request header, so they are omitted; only these
+// bounded aggregates are reported.
+type fairnessDumpState struct {
+	TotalPrograms int     `json:"totalPrograms"`
+	TotalInFlight int64   `json:"totalInFlight"`
+	FairnessIndex float64 `json:"fairnessIndex"`
+}
+
+// DumpState reports aggregate fairness health: how many programs are tracked,
+// the total in-flight requests across them, and Jain's fairness index. Per-program
+// IDs are deliberately excluded because they are user-controlled and high-cardinality.
+// All three values come from a single pass over the program map.
+func (p *ProgramAwarePlugin) DumpState() (json.RawMessage, error) {
+	var totalPrograms int
+	var totalInFlight int64
+	var sum, sumSq, n float64
+	p.programMetrics.Range(func(_, value any) bool {
+		totalPrograms++
+		m, ok := value.(*ProgramMetrics)
+		if !ok {
+			return true
+		}
+		totalInFlight += m.InFlight()
+		if m.WaitCount() > 0 {
+			x := m.AverageWaitTime()
+			sum += x
+			sumSq += x * x
+			n++
+		}
+		return true
+	})
+	return json.Marshal(fairnessDumpState{
+		TotalPrograms: totalPrograms,
+		TotalInFlight: totalInFlight,
+		FairnessIndex: jainFairnessIndex(sum, sumSq, n),
+	})
 }
 
 // getStrategy falls back to a default LAS strategy for zero-value plugin
@@ -261,6 +301,16 @@ func (p *ProgramAwarePlugin) evictKey(key any) {
 	}
 }
 
+// jainFairnessIndex returns Jain's fairness index for the given sum, sum of
+// squares, and count of per-program wait observations. It is 1.0 (perfectly
+// fair) when fewer than two programs have observations.
+func jainFairnessIndex(sum, sumSq, n float64) float64 {
+	if n <= 1 || sumSq == 0 {
+		return 1.0
+	}
+	return (sum * sum) / (n * sumSq)
+}
+
 // computeFairnessIndex returns Jain's Fairness Index over the average wait
 // time per program. Programs with no wait observations are skipped.
 func (p *ProgramAwarePlugin) computeFairnessIndex() float64 {
@@ -279,8 +329,5 @@ func (p *ProgramAwarePlugin) computeFairnessIndex() float64 {
 		n++
 		return true
 	})
-	if n <= 1 || sumSq == 0 {
-		return 1.0
-	}
-	return (sum * sum) / (n * sumSq)
+	return jainFairnessIndex(sum, sumSq, n)
 }

--- a/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
+++ b/pkg/epp/framework/plugins/flowcontrol/fairness/program-aware/plugin_test.go
@@ -255,3 +255,44 @@ func TestGetOrCreateMetrics_Idempotent(t *testing.T) {
 	b := p.getOrCreateMetrics("alpha")
 	assert.Same(t, a, b)
 }
+
+func TestDumpState(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+	p.getOrCreateMetrics("prog-a").RecordDispatched(time.Now().Add(-10 * time.Millisecond))
+	p.getOrCreateMetrics("prog-b").RecordDispatched(time.Now().Add(-20 * time.Millisecond))
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+
+	var state fairnessDumpState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, 2, state.TotalPrograms)
+	assert.Equal(t, int64(2), state.TotalInFlight)
+	assert.GreaterOrEqual(t, state.FairnessIndex, 0.0)
+	assert.LessOrEqual(t, state.FairnessIndex, 1.0)
+}
+
+func TestDumpStateOmitsProgramIDs(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+	// Program IDs come from a user-controlled header and must never be dumped.
+	p.getOrCreateMetrics("secret-tenant-xyz").RecordDispatched(time.Now().Add(-5 * time.Millisecond))
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "secret-tenant-xyz")
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	p := &ProgramAwarePlugin{}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.True(t, json.Valid(payload))
+
+	var state fairnessDumpState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, 0, state.TotalPrograms)
+	assert.Equal(t, int64(0), state.TotalInFlight)
+	// With no programs the policy is trivially fair.
+	assert.Equal(t, 1.0, state.FairnessIndex)
+}

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/README.md
@@ -12,8 +12,10 @@ For each request, the plugin consumes `request.Body.TokenizedPrompt` (token IDs)
 
 - `autoTune` (bool, optional, default: `true`): Infer `blockSizeTokens` and `lruCapacityPerServer` from endpoint metrics when available.
 - `blockSizeTokens` (int, optional, default: `16`): Prefix block size in tokens. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics. Values below the minimum of `64` are clamped up at request time (see #1158), so the `16` default is effectively `64` absent a larger metric/configured value.
-- `maxPrefixBlocksToMatch` (int, optional, default: `2048`): Maximum number of prefix blocks hashed and matched per request. Not auto-tuned. `0` disables matching (zero blocks hashed).
+- `maxPrefixBlocksToMatch` (int, optional, default: `2048`): Maximum number of prefix blocks hashed and matched per request. Not auto-tuned. Applies only when `maxPrefixTokensToMatch` is `0`.
 - `maxPrefixTokensToMatch` (int, optional, default: `131072`): Cap expressed in tokens instead of blocks (`maxBlocks = maxPrefixTokensToMatch / blockSizeTokens`). Not auto-tuned. Takes precedence over `maxPrefixBlocksToMatch` when set (> 0); set to `0` to fall back to the block-based cap. The `131072` default (128K, the context window of large production models such as gpt-oss 120b) is a reasonable upper bound that covers the long-prompt use cases seen in production.
+
+Setting both caps to `0` matches the whole prompt. Prompt length is bounded by the model server's context window, so this caps matching at one context window without needing to name a token count. It raises EPP CPU on long prompts (see [operations](../../../../../../../docs/operations.md)); to turn prefix matching off, remove this producer from the configuration rather than zeroing the caps.
 - `lruCapacityPerServer` (int, optional, default: `31250`): Per-pod LRU index capacity. Used when `autoTune` is false or endpoint metrics are unavailable; ignored when auto-tuned from metrics.
 - `blockSize` (int, optional): Deprecated — character-based block size. Use `blockSizeTokens` instead.
 

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin.go
@@ -227,11 +227,7 @@ func (p *dataProducer) PluginState() *plugin.PluginState {
 // Produce is called by the director before scheduling requests.
 func (p *dataProducer) Produce(ctx context.Context, request *fwksched.InferenceRequest, pods []fwksched.Endpoint) error {
 	blockSize := p.GetBlockSize(pods)
-	maxBlocks := p.config.MaxPrefixBlocksToMatch
-	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
-		maxBlocks = p.config.MaxPrefixTokensToMatch / blockSize
-	}
-	perPromptHashes := prefixhash.GetBlockHashes(ctx, request, blockSize, maxBlocks)
+	perPromptHashes := prefixhash.GetBlockHashes(ctx, request, blockSize, p.resolveMaxBlocks(blockSize))
 
 	prefixCacheServers := make(map[ServerID]int)
 	totalBlocks := 0
@@ -357,6 +353,24 @@ func (p *dataProducer) GetBlockSize(endpoints []fwksched.Endpoint) int {
 		return minBlockSizeTokens
 	}
 	return blockSize
+}
+
+// resolveMaxBlocks returns the per-request cap on hashed prefix blocks.
+//
+// MaxPrefixTokensToMatch wins when set, converting tokens to blocks at the
+// effective block size. Zeroing both caps means unlimited: prompt length is
+// already bounded by the model server's context window, so the whole prompt is
+// at most one context window of tokens. A token cap smaller than the block size
+// still resolves to 0 and hashes nothing; that is a misconfiguration, not a
+// request for unlimited matching.
+func (p *dataProducer) resolveMaxBlocks(blockSize int) int {
+	if p.config.MaxPrefixTokensToMatch > 0 && blockSize > 0 {
+		return p.config.MaxPrefixTokensToMatch / blockSize
+	}
+	if p.config.MaxPrefixBlocksToMatch == 0 {
+		return unlimitedPrefixBlocks
+	}
+	return p.config.MaxPrefixBlocksToMatch
 }
 
 // ApproxPrefixCacheFactory is the factory function for the prefix cache data producer plugin.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/plugin_test.go
@@ -443,6 +443,40 @@ func TestMaxPrefixTokensToMatch(t *testing.T) {
 	assert.Equal(t, 3, len(state2.PerPromptHashes[0]), "should fall back to MaxPrefixBlocksToMatch when MaxPrefixTokensToMatch is 0")
 }
 
+// TestMaxPrefixBothCapsZeroMatchesEverything verifies that zeroing both caps
+// hashes the whole prompt rather than nothing. The prompt length is already
+// bounded by the model server's context window, so an absent cap is an implicit
+// max_model_len cap.
+func TestMaxPrefixBothCapsZeroMatchesEverything(t *testing.T) {
+	disableMinBlockSizeClamp(t)
+	cfg := config{
+		BlockSizeTokens:        1,
+		MaxPrefixTokensToMatch: 0,
+		MaxPrefixBlocksToMatch: 0,
+		LRUCapacityPerServer:   defaultLRUCapacityPerServer,
+	}
+	p, err := newDataProducer(context.Background(), ApproxPrefixCachePluginType, cfg, testHandle())
+	assert.NoError(t, err)
+
+	endpoint := fwksched.NewEndpoint(
+		&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}},
+		fwkdl.NewMetrics(), fwkdl.NewAttributes(),
+	)
+
+	req := &fwksched.InferenceRequest{
+		RequestID:   uuid.NewString(),
+		TargetModel: "test-model",
+		Body:        tokenizedBody([]uint32{1, 2, 3, 4}),
+	}
+
+	err = p.Produce(context.Background(), req, []fwksched.Endpoint{endpoint})
+	assert.NoError(t, err)
+
+	state, err := plugin.ReadPluginStateKey[*SchedulingContextState](p.PluginState(), req.RequestID, plugin.StateKey(ApproxPrefixCachePluginType))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(state.PerPromptHashes[0]), "both caps at 0 should hash every block in the prompt")
+}
+
 // TestGetBlockSize_AutotuneClampsBelowMinimum verifies that when AutoTune is on and
 // the endpoint reports a small CacheBlockSize, GetBlockSize floors the result at
 // minBlockSizeTokens to bound EPP indexer memory. See issue #1158.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/approximateprefix/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package approximateprefix
 
 import (
+	"math"
 	"time"
 
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -99,7 +100,8 @@ const (
 	defaultBlockSizeTokens = 16
 
 	// defaultMaxPrefixBlocks is the fallback block cap, consulted only when
-	// MaxPrefixTokensToMatch is 0; the default token cap otherwise supersedes it.
+	// MaxPrefixTokensToMatch is 0 and MaxPrefixBlocksToMatch is non-zero; the
+	// default token cap otherwise supersedes it.
 	// Two long requests with the same prefix up to this limit will be indistinguishable.
 	// This parameter provides a trade-off between cache size, prefix matching speed and matching
 	// accuracy. Use a small value if most requests are short to reduce cache size and speed up the
@@ -111,6 +113,12 @@ const (
 	// that covers the long-prompt use cases seen in production. It takes precedence
 	// over defaultMaxPrefixBlocks: maxBlocks = defaultMaxPrefixTokens / blockSizeTokens.
 	defaultMaxPrefixTokens = 131072
+
+	// unlimitedPrefixBlocks is the block cap used when both MaxPrefixTokensToMatch
+	// and MaxPrefixBlocksToMatch are 0. Prompt length is already bounded by the
+	// model server's context window, so an absent cap matches at most one context
+	// window of tokens.
+	unlimitedPrefixBlocks = math.MaxInt
 
 	// defaultLRUCapacityPerServer is the default capacity of the LRU indexer per server.
 	// The indexer is an approximation to the actual prefix LRU cache state on the model servers per server (pod).
@@ -135,11 +143,12 @@ type config struct {
 	BlockSize int `json:"blockSize"`
 	// Deprecated: use MaxPrefixTokensToMatch, which caps prefix matching in tokens
 	// independent of BlockSizeTokens. MaxPrefixBlocksToMatch applies only when
-	// MaxPrefixTokensToMatch is 0.
+	// MaxPrefixTokensToMatch is 0. Setting both to 0 matches the whole prompt.
 	MaxPrefixBlocksToMatch int `json:"maxPrefixBlocksToMatch"`
 	// MaxPrefixTokensToMatch is the maximum number of prefix tokens to match.
 	// When set (> 0), it takes precedence over MaxPrefixBlocksToMatch by computing
-	// maxBlocks = MaxPrefixTokensToMatch / blockSizeTokens.
+	// maxBlocks = MaxPrefixTokensToMatch / blockSizeTokens. Setting both caps to 0
+	// matches the whole prompt.
 	MaxPrefixTokensToMatch int `json:"maxPrefixTokensToMatch"`
 	// Max capacity size of the LRU indexer in number of entries per server (pod).
 	LRUCapacityPerServer int `json:"lruCapacityPerServer"`

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -59,6 +60,7 @@ var (
 	_ requestcontrol.DataProducer = &Producer{}
 	_ requestcontrol.PreRequest   = &Producer{}
 	_ fwkdl.EndpointExtractor     = &Producer{}
+	_ plugin.StateDumper          = &Producer{}
 )
 
 // Parameters configures the multimodal encoder-cache data producer.
@@ -170,6 +172,77 @@ func (p *Producer) cleanupLoop(ctx context.Context) {
 // TypedName returns the plugin type/name.
 func (p *Producer) TypedName() plugin.TypedName {
 	return p.typedName
+}
+
+const maxDebugDumpPods = 100
+
+// encoderCacheState is the snapshot returned by DumpState: the known pods from
+// the datalayer and per-pod cached-item counts. The multimodal content hashes
+// (the cache keys) are not exposed. Both lists are capped at MaxPods (PodList by
+// name, Pods by item count) and a list is partial when its matching total
+// exceeds MaxPods. PodList is sampled just before the per-pod view rather than
+// atomically with it, so the snapshot is best-effort: the two need not be
+// perfectly consistent, and a freshly tracked pod can appear in Pods but not yet
+// in PodList.
+type encoderCacheState struct {
+	PodList        []string       `json:"podList"`
+	TotalKnownPods int            `json:"totalKnownPods"`
+	Pods           []podItemCount `json:"pods"`
+	TotalPods      int            `json:"totalPods"`
+	MaxPods        int            `json:"maxPods"`
+}
+
+type podItemCount struct {
+	Pod   string `json:"pod"`
+	Items int    `json:"items"`
+}
+
+// DumpState reports the known pods from the datalayer and how many encoder-cache
+// items are tracked per pod, ordered by count (most first) and capped to
+// maxDebugDumpPods so the payload stays bounded. Pod identities and counts are
+// exposed; the content hashes (cache keys) are not.
+func (p *Producer) DumpState() (json.RawMessage, error) {
+	// podList() is the datalayer accessor; call it outside the cache lock, as
+	// removeStalePods does.
+	podList := []string{}
+	var totalKnownPods int
+	if p.podList != nil {
+		known := p.podList()
+		totalKnownPods = len(known)
+		podList = make([]string, 0, len(known))
+		for _, nn := range known {
+			podList = append(podList, nn.String())
+		}
+		sort.Strings(podList)
+		if len(podList) > maxDebugDumpPods {
+			podList = podList[:maxDebugDumpPods]
+		}
+	}
+
+	p.mutex.RLock()
+	state := encoderCacheState{
+		PodList:        podList,
+		TotalKnownPods: totalKnownPods,
+		MaxPods:        maxDebugDumpPods,
+		TotalPods:      len(p.caches),
+	}
+	pods := make([]podItemCount, 0, len(p.caches))
+	for pod, cache := range p.caches {
+		pods = append(pods, podItemCount{Pod: pod, Items: cache.Len()})
+	}
+	p.mutex.RUnlock()
+
+	sort.SliceStable(pods, func(a, b int) bool {
+		if pods[a].Items != pods[b].Items {
+			return pods[a].Items > pods[b].Items
+		}
+		return pods[a].Pod < pods[b].Pod
+	})
+	if len(pods) > maxDebugDumpPods {
+		pods = pods[:maxDebugDumpPods]
+	}
+	state.Pods = pods
+	return json.Marshal(state)
 }
 
 // Produces returns the data keys this plugin produces.

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/multimodal/producer_test.go
@@ -19,7 +19,9 @@ package multimodal
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -288,4 +290,111 @@ func assertMatchInfo(t *testing.T, p *Producer, endpoint scheduling.Endpoint, ma
 	require.True(t, ok)
 	assert.ElementsMatch(t, matchedItems, info.MatchedItems())
 	assert.ElementsMatch(t, requestItems, info.RequestItems())
+}
+
+func TestDumpState(t *testing.T) {
+	podA := k8stypes.NamespacedName{Namespace: "default", Name: "pod-a"}
+	podB := k8stypes.NamespacedName{Namespace: "default", Name: "pod-b"}
+	podC := k8stypes.NamespacedName{Namespace: "default", Name: "pod-c"}
+	// podList is the datalayer's known pods (unsorted, and includes pod-c which
+	// has no cache entries); the per-pod cache view is tracked separately, so it
+	// is usually but not necessarily a subset.
+	podList := func() []k8stypes.NamespacedName {
+		return []k8stypes.NamespacedName{podB, podA, podC}
+	}
+	p, err := New(context.Background(), "test", &Parameters{}, podList)
+	require.NoError(t, err)
+
+	p.putCacheEntry("h1", podA)
+	p.putCacheEntry("h2", podA)
+	p.putCacheEntry("h3", podA)
+	p.putCacheEntry("h1", podB)
+	p.putCacheEntry("h2", podB)
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	// Content hashes (cache keys) must never reach the dump.
+	assert.NotContains(t, string(payload), "h1")
+
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, encoderCacheState{
+		PodList:        []string{"default/pod-a", "default/pod-b", "default/pod-c"},
+		TotalKnownPods: 3,
+		Pods: []podItemCount{
+			{Pod: "default/pod-a", Items: 3},
+			{Pod: "default/pod-b", Items: 2},
+		},
+		TotalPods: 2,
+		MaxPods:   maxDebugDumpPods,
+	}, state)
+}
+
+func TestDumpStateCapsPods(t *testing.T) {
+	p, err := New(context.Background(), "test", &Parameters{}, nil)
+	require.NoError(t, err)
+
+	const extra = 5
+	for i := 0; i < maxDebugDumpPods+extra; i++ {
+		pod := k8stypes.NamespacedName{Namespace: "default", Name: fmt.Sprintf("pod-%03d", i)}
+		for j := 0; j <= i; j++ {
+			p.putCacheEntry(fmt.Sprintf("h-%03d-%03d", i, j), pod)
+		}
+	}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	// The dump is partial: TotalPods exceeds the returned count, capped at MaxPods.
+	assert.Equal(t, maxDebugDumpPods+extra, state.TotalPods)
+	assert.Greater(t, state.TotalPods, state.MaxPods)
+	assert.Len(t, state.Pods, maxDebugDumpPods)
+	// The pod holding the most items is listed first.
+	assert.Equal(t, "default/pod-104", state.Pods[0].Pod)
+	assert.Equal(t, maxDebugDumpPods+extra, state.Pods[0].Items)
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	p, err := New(context.Background(), "test", &Parameters{}, nil)
+	require.NoError(t, err)
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.True(t, json.Valid(payload))
+	// Empty lists serialize as [] not null, matching the documented response shape.
+	assert.Contains(t, string(payload), `"podList":[]`)
+	assert.Contains(t, string(payload), `"pods":[]`)
+
+	var state encoderCacheState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Empty(t, state.Pods)
+	assert.Equal(t, 0, state.TotalPods)
+	assert.Equal(t, 0, state.TotalKnownPods)
+	assert.Equal(t, maxDebugDumpPods, state.MaxPods)
+}
+
+func TestDumpStateConcurrentWithWrites(t *testing.T) {
+	p, err := New(context.Background(), "test", &Parameters{}, nil)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			pod := k8stypes.NamespacedName{Namespace: "default", Name: fmt.Sprintf("pod-%03d", i)}
+			p.putCacheEntry(fmt.Sprintf("h-%d", i), pod)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			if _, err := p.DumpState(); err != nil {
+				t.Errorf("DumpState returned error: %v", err)
+			}
+		}
+	}()
+	wg.Wait()
 }

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -64,7 +65,19 @@ type PluginConfig struct {
 	SpeculativeTTL string `json:"speculativeTTL"`
 }
 
-var _ requestcontrol.DataProducer = &Producer{}
+var (
+	_ requestcontrol.DataProducer = &Producer{}
+	_ plugin.StateDumper          = &Producer{}
+)
+
+// subscriberManager is the subset of kvevents.SubscriberManager the producer
+// relies on, narrowed so tests can substitute a fake.
+type subscriberManager interface {
+	EnsureSubscriber(ctx context.Context, podIdentifier, endpoint, topicFilter string, remoteSocket bool) error
+	RemoveSubscriber(ctx context.Context, podIdentifier string)
+	GetActiveSubscribers() ([]string, []string)
+	Shutdown(ctx context.Context)
+}
 
 // Producer is a DataProducer plugin that maintains a KV-block prefix-cache
 // index by subscribing to vLLM KV-events and writes per-endpoint
@@ -78,7 +91,7 @@ type Producer struct {
 	typedName      plugin.TypedName
 	kvCacheIndexer kvCacheIndexer
 
-	subscribersManager *kvevents.SubscriberManager
+	subscribersManager subscriberManager
 	kvEventsConfig     *kvevents.Config
 
 	kvBlockScorer kvcache.KVBlockScorer
@@ -200,6 +213,70 @@ func New(ctx context.Context, name string, config PluginConfig) (*Producer, erro
 // TypedName returns the plugin's registered type and name.
 func (p *Producer) TypedName() plugin.TypedName {
 	return p.typedName
+}
+
+// Debug-dump caps keep the payload bounded. A list is partial when its matching
+// TotalX exceeds MaxX.
+const (
+	maxDumpSubscribers        = 100
+	maxDumpSpeculativeEntries = 100
+)
+
+// precisePrefixState is the snapshot returned by DumpState. The KV-block index
+// is keyed by prompt-derived block hashes and is not enumerable, so it is not
+// reported; the active subscriber pod identities and the live speculative
+// request ids are enumerated (sorted and capped) for debugging.
+type precisePrefixState struct {
+	Subscribers             []string `json:"subscribers"`
+	TotalSubscribers        int      `json:"totalSubscribers"`
+	MaxSubscribers          int      `json:"maxSubscribers"`
+	SpeculativeIndexing     bool     `json:"speculativeIndexing"`
+	SpeculativeEntries      []string `json:"speculativeEntries"`
+	TotalSpeculativeEntries int      `json:"totalSpeculativeEntries"`
+	MaxSpeculativeEntries   int      `json:"maxSpeculativeEntries"`
+	BlockSizeTokens         int      `json:"blockSizeTokens"`
+}
+
+// DumpState reports the producer's bounded operational state: the active
+// KV-event subscriber pod identities, whether speculative indexing is on and
+// the live speculative request ids, and the block size in tokens. Both lists
+// are sorted and capped; the prompt-derived block index is not exposed.
+func (p *Producer) DumpState() (json.RawMessage, error) {
+	subscribers := []string{}
+	var totalSubscribers int
+	if p.subscribersManager != nil {
+		ids, _ := p.subscribersManager.GetActiveSubscribers()
+		totalSubscribers = len(ids)
+		subscribers = sortedCapped(ids, maxDumpSubscribers)
+	}
+	speculativeEntries := []string{}
+	var totalSpeculativeEntries int
+	if p.speculativeCache != nil {
+		keys := p.speculativeCache.Keys()
+		totalSpeculativeEntries = len(keys)
+		speculativeEntries = sortedCapped(keys, maxDumpSpeculativeEntries)
+	}
+	return json.Marshal(precisePrefixState{
+		Subscribers:             subscribers,
+		TotalSubscribers:        totalSubscribers,
+		MaxSubscribers:          maxDumpSubscribers,
+		SpeculativeIndexing:     p.speculativeEnabled,
+		SpeculativeEntries:      speculativeEntries,
+		TotalSpeculativeEntries: totalSpeculativeEntries,
+		MaxSpeculativeEntries:   maxDumpSpeculativeEntries,
+		BlockSizeTokens:         p.blockSizeTokens,
+	})
+}
+
+// sortedCapped returns a sorted copy of in (never nil, so empty lists serialize
+// as [] not null), truncated to limit entries.
+func sortedCapped(in []string, limit int) []string {
+	out := append([]string{}, in...)
+	sort.Strings(out)
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
 }
 
 // Produces declares the PrefixCacheMatchInfoDataKey published per endpoint,

--- a/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/producer_test.go
@@ -19,8 +19,10 @@ package preciseprefixcache
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/llm-d/llm-d-router/pkg/kvcache"
 	"github.com/llm-d/llm-d-router/pkg/kvcache/kvblock"
 	"github.com/llm-d/llm-d-router/pkg/kvevents"
@@ -672,4 +674,100 @@ func TestNew_BlockSizeFlowsViaTokenProcessor(t *testing.T) {
 			assert.Equal(t, 1, info.TotalBlocks())
 		})
 	}
+}
+
+type fakeSubscriberManager struct {
+	ids       []string
+	endpoints []string
+}
+
+func (f *fakeSubscriberManager) EnsureSubscriber(_ context.Context, _, _, _ string, _ bool) error {
+	return nil
+}
+func (f *fakeSubscriberManager) RemoveSubscriber(_ context.Context, _ string) {}
+func (f *fakeSubscriberManager) GetActiveSubscribers() ([]string, []string) {
+	return f.ids, f.endpoints
+}
+func (f *fakeSubscriberManager) Shutdown(_ context.Context) {}
+
+func TestDumpState(t *testing.T) {
+	// Start() is intentionally not called: NoTTL entries never expire, and the
+	// enumeration helpers work on an unstarted cache.
+	specCache := ttlcache.New[string, *speculativeEntries]()
+	specCache.Set("req-2", &speculativeEntries{}, ttlcache.NoTTL)
+	specCache.Set("req-1", &speculativeEntries{}, ttlcache.NoTTL)
+
+	p := &Producer{
+		typedName:          plugin.TypedName{Type: PluginType, Name: "x"},
+		subscribersManager: &fakeSubscriberManager{ids: []string{"ns/pod-b", "ns/pod-a"}},
+		speculativeCache:   specCache,
+		speculativeEnabled: true,
+		blockSizeTokens:    64,
+	}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	// Subscriber pod identities and live request ids are enumerated for debugging.
+	assert.Contains(t, string(payload), "ns/pod-a")
+
+	var state precisePrefixState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, precisePrefixState{
+		Subscribers:             []string{"ns/pod-a", "ns/pod-b"},
+		TotalSubscribers:        2,
+		MaxSubscribers:          maxDumpSubscribers,
+		SpeculativeIndexing:     true,
+		SpeculativeEntries:      []string{"req-1", "req-2"},
+		TotalSpeculativeEntries: 2,
+		MaxSpeculativeEntries:   maxDumpSpeculativeEntries,
+		BlockSizeTokens:         64,
+	}, state)
+}
+
+func TestDumpStateEmpty(t *testing.T) {
+	p := &Producer{}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+	assert.True(t, json.Valid(payload))
+	// Empty lists serialize as [] not null, matching the documented response shape.
+	assert.Contains(t, string(payload), `"subscribers":[]`)
+	assert.Contains(t, string(payload), `"speculativeEntries":[]`)
+
+	var state precisePrefixState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	assert.Equal(t, precisePrefixState{
+		Subscribers:           []string{},
+		SpeculativeEntries:    []string{},
+		MaxSubscribers:        maxDumpSubscribers,
+		MaxSpeculativeEntries: maxDumpSpeculativeEntries,
+	}, state)
+}
+
+func TestDumpStateCaps(t *testing.T) {
+	specCache := ttlcache.New[string, *speculativeEntries]()
+	ids := make([]string, 0, maxDumpSubscribers+5)
+	for i := 0; i < maxDumpSubscribers+5; i++ {
+		ids = append(ids, fmt.Sprintf("ns/pod-%03d", i))
+	}
+	for i := 0; i < maxDumpSpeculativeEntries+7; i++ {
+		specCache.Set(fmt.Sprintf("req-%04d", i), &speculativeEntries{}, ttlcache.NoTTL)
+	}
+
+	p := &Producer{
+		subscribersManager: &fakeSubscriberManager{ids: ids},
+		speculativeCache:   specCache,
+	}
+
+	payload, err := p.DumpState()
+	require.NoError(t, err)
+
+	var state precisePrefixState
+	require.NoError(t, json.Unmarshal(payload, &state))
+	// Lists are capped, but the totals report the full counts so a consumer can
+	// tell the dump is partial from totalX > maxX.
+	assert.Len(t, state.Subscribers, maxDumpSubscribers)
+	assert.Equal(t, maxDumpSubscribers+5, state.TotalSubscribers)
+	assert.Len(t, state.SpeculativeEntries, maxDumpSpeculativeEntries)
+	assert.Equal(t, maxDumpSpeculativeEntries+7, state.TotalSpeculativeEntries)
 }

--- a/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/README.md
+++ b/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/README.md
@@ -1,37 +1,44 @@
 # Agent Identity
 
 **Type:** `agent-identity`
-**Interfaces:** `requestcontrol.PreAdmitter`
+**Interfaces:** `requestcontrol.RequestHeaderProcessor`
 
-Resolves a per-session identity from agent-specific HTTP headers and writes it into `InferenceRequest.FairnessID`, so every turn of an agent session lands in the same flow-control fairness queue.
+Resolves a per-session identity from agent-specific HTTP headers and stores it as a request attribute (`"agent-identity"`) for use by other subsystems. The Director then derives `FairnessID` from this attribute when no explicit fairness header is present, so every turn of an agent session lands in the same flow-control fairness queue.
 
 ## What It Does
 
-The plugin runs after request assembly and before admission control. If the request does not already carry an explicit fairness ID (`x-llm-d-inference-fairness-id`, or its deprecated alias `x-gateway-inference-fairness-id`), it inspects a fixed set of agent session headers and copies the first non-empty value into `FairnessID`. The flow-control layer keys its queues on `FlowKey{ID: FairnessID, Priority}`, so this turns "all turns from one agent session" into "all turns share one queue."
+The plugin runs after request assembly and before admission control. It inspects a fixed set of agent session headers and stores the first non-empty value as a request attribute via `request.PutAttribute("agent-identity", value)`.
 
-Without it, every request from a given agent session falls into the default fairness queue alongside unrelated traffic, and per-session fairness, prefix-cache affinity, and per-tenant rate limiting all collapse to per-request granularity.
+The plugin stores the identity as a request attribute only — it does not set `FairnessID`. The Director reads the `"agent-identity"` attribute and derives `FairnessID` from it when no explicit `x-llm-d-inference-fairness-id` header is present. This separation means the agent identity is available as a reliable signal to other subsystems (scheduling, KV cache control, etc.) without being conflated with flow-control identity.
 
 ## How It Works
 
-1. If `request.FairnessID` is already non-empty, return immediately — an explicit upstream `x-llm-d-inference-fairness-id` (or its deprecated alias `x-gateway-inference-fairness-id`) is read into `FairnessID` before the plugin runs and always wins over a derived one.
-2. Otherwise, walk the priority list of agent session headers and copy the first non-empty match into `request.FairnessID`. Operator-supplied entries from `additionalSessionHeaders` come first, followed by the built-in defaults in this order:
+1. Walk the priority list of agent session headers and store the first non-empty match as the `"agent-identity"` request attribute. Operator-supplied entries from `additionalSessionHeaders` come first, followed by the built-in defaults in this order:
    1. `x-claude-code-session-id` (Claude Code)
    2. `x-session-affinity` (OpenCode)
    3. `session-id` (Codex)
    4. `session_id` (Codex, legacy underscored fallback)
-3. If nothing matches, leave `FairnessID` empty and return — the director applies `metadata.DefaultFairnessID` after the plugin returns, so the request is still admitted, just into the shared default queue.
+2. If nothing matches, no attribute is stored — the Director falls through to `metadata.DefaultFairnessID`, so the request is still admitted, just into the shared default queue.
+
+After the plugin returns, the Director checks:
+1. If `x-llm-d-inference-fairness-id` header is set → use as FairnessID (explicit always wins).
+2. Else if `"agent-identity"` attribute exists → copy to FairnessID.
+3. Else → `"default-flow"`.
 
 The plugin is stateless and safe under concurrent use.
 
 ## Inputs Consumed
 
 - `scheduling.InferenceRequest.Headers` — read-only lookup of the session headers above (built-in defaults plus any from `additionalSessionHeaders`). Keys are expected lowercase (Envoy normalizes inbound headers).
-- `scheduling.InferenceRequest.FairnessID` — read to detect an upstream override; written when an agent header matches.
+
+## Outputs Produced
+
+- `scheduling.InferenceRequest` attribute `"agent-identity"` (`string`) — set when a session header matches.
 
 ## Configuration
 
 **Location:** Top-level `plugins:` list in the `EndpointPickerConfig`.
-**Enabled by default:** No. Add a `- type: agent-identity` entry to enable; the runner discovers it as a `PreAdmitter` and wires it in.
+**Enabled by default:** No. Add a `- type: agent-identity` entry to enable; the runner discovers it as a `RequestHeaderProcessor` and wires it in.
 
 ### Parameters
 

--- a/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity.go
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package agentidentity provides a PreAdmitter plugin that resolves
-// agent identity from provider-specific headers into the FairnessID field.
+// Package agentidentity provides a RequestHeaderProcessor plugin that resolves
+// agent identity from provider-specific headers and stores it as a request
+// attribute for use by other subsystems (flow control, scheduling, KV cache, etc.).
 package agentidentity
 
 import (
@@ -30,8 +31,12 @@ import (
 )
 
 const (
-	PluginType = "agent-identity"
-
+	// AgentIdentityKey is the request-attribute key under which
+	// this plugin publishes the resolved agent identity.
+	// Downstream consumers such as the Director read it
+	// via scheduling.ReadRequestAttribute to derive the FairnessID.
+	AgentIdentityKey        = "agent-identity"
+	PluginType              = "agent-identity"
 	ClaudeCodeSessionHeader = "x-claude-code-session-id"
 	OpenCodeSessionHeader   = "x-session-affinity"
 	// CodexSessionHeader is the current (Codex >= 0.131.0) hyphenated form.
@@ -92,9 +97,10 @@ func mergeHeaders(extras, defaults []string) []string {
 }
 
 // compile-time interface assertion
-var _ requestcontrol.PreAdmitter = &Plugin{}
+var _ requestcontrol.RequestHeaderProcessor = &Plugin{}
 
-// Plugin resolves agent identity from provider-specific headers into FairnessID.
+// Plugin resolves agent identity from provider-specific headers and stores it
+// as a request attribute for use by other subsystems.
 type Plugin struct {
 	typedName       plugin.TypedName
 	priorityHeaders []string
@@ -104,17 +110,12 @@ func (p *Plugin) TypedName() plugin.TypedName {
 	return p.typedName
 }
 
-func (p *Plugin) PreAdmit(_ context.Context, request *scheduling.InferenceRequest) error {
-	if request.FairnessID != "" {
-		return nil
-	}
-
+func (p *Plugin) RequestHeader(_ context.Context, request *scheduling.InferenceRequest) error {
 	for _, header := range p.priorityHeaders {
 		if id := request.Headers[header]; id != "" {
-			request.FairnessID = id
+			request.PutAttribute(AgentIdentityKey, id)
 			return nil
 		}
 	}
-
 	return nil
 }

--- a/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity_test.go
+++ b/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity/agent_identity_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // newDefaultPlugin builds a Plugin with no parameters — the built-in defaults.
-// All PreAdmit tests below use this so they exercise the same code
+// All RequestHeader tests below use this so they exercise the same code
 // path as production-default configs.
 func newDefaultPlugin(t *testing.T) *Plugin {
 	t.Helper()
@@ -39,122 +39,116 @@ func newDefaultPlugin(t *testing.T) *Plugin {
 	return pi.(*Plugin)
 }
 
-func TestPreAdmit(t *testing.T) {
+func TestRequestHeader(t *testing.T) {
 	p := newDefaultPlugin(t)
 
 	tests := []struct {
-		name           string
-		fairnessID     string
-		headers        map[string]string
-		body           *fwkrh.InferenceRequestBody
-		wantFairnessID string
+		name          string
+		headers       map[string]string
+		body          *fwkrh.InferenceRequestBody
+		wantIdentity  string
+		wantAttrFound bool
 	}{
 		{
-			name:           "explicit fairness ID is preserved",
-			fairnessID:     "my-explicit-id",
-			headers:        map[string]string{ClaudeCodeSessionHeader: "session-abc"},
-			wantFairnessID: "my-explicit-id",
+			name:          "claude code session header",
+			headers:       map[string]string{ClaudeCodeSessionHeader: "session-abc"},
+			wantIdentity:  "session-abc",
+			wantAttrFound: true,
 		},
 		{
-			name:           "claude code session header used when fairness ID is empty",
-			fairnessID:     "",
-			headers:        map[string]string{ClaudeCodeSessionHeader: "session-abc"},
-			wantFairnessID: "session-abc",
+			name:          "opencode session header",
+			headers:       map[string]string{OpenCodeSessionHeader: "oc-session-1"},
+			wantIdentity:  "oc-session-1",
+			wantAttrFound: true,
 		},
 		{
-			name:           "opencode session header",
-			fairnessID:     "",
-			headers:        map[string]string{OpenCodeSessionHeader: "oc-session-1"},
-			wantFairnessID: "oc-session-1",
+			name:          "codex session header (hyphenated, >= 0.131.0)",
+			headers:       map[string]string{CodexSessionHeader: "codex-session-1"},
+			wantIdentity:  "codex-session-1",
+			wantAttrFound: true,
 		},
 		{
-			name:           "codex session header (hyphenated, >= 0.131.0)",
-			fairnessID:     "",
-			headers:        map[string]string{CodexSessionHeader: "codex-session-1"},
-			wantFairnessID: "codex-session-1",
+			name:          "codex legacy session header (underscored, <= 0.130.x)",
+			headers:       map[string]string{CodexSessionHeaderLegacy: "codex-legacy-1"},
+			wantIdentity:  "codex-legacy-1",
+			wantAttrFound: true,
 		},
 		{
-			name:           "codex legacy session header (underscored, <= 0.130.x)",
-			fairnessID:     "",
-			headers:        map[string]string{CodexSessionHeaderLegacy: "codex-legacy-1"},
-			wantFairnessID: "codex-legacy-1",
-		},
-		{
-			name:       "priority order: codex hyphenated wins over legacy underscored",
-			fairnessID: "",
+			name: "priority order: codex hyphenated wins over legacy underscored",
 			headers: map[string]string{
 				CodexSessionHeader:       "codex-new",
 				CodexSessionHeaderLegacy: "codex-old",
 			},
-			wantFairnessID: "codex-new",
+			wantIdentity:  "codex-new",
+			wantAttrFound: true,
 		},
 		{
-			name:       "priority order: claude code wins over opencode",
-			fairnessID: "",
+			name: "priority order: claude code wins over opencode",
 			headers: map[string]string{
 				ClaudeCodeSessionHeader: "session-abc",
 				OpenCodeSessionHeader:   "oc-session-1",
 			},
-			wantFairnessID: "session-abc",
+			wantIdentity:  "session-abc",
+			wantAttrFound: true,
 		},
 		{
-			name:       "priority order: opencode wins over codex",
-			fairnessID: "",
+			name: "priority order: opencode wins over codex",
 			headers: map[string]string{
 				OpenCodeSessionHeader: "oc-session-1",
 				CodexSessionHeader:    "codex-session-1",
 			},
-			wantFairnessID: "oc-session-1",
+			wantIdentity:  "oc-session-1",
+			wantAttrFound: true,
 		},
 		{
-			name:       "previous_response_id in body is ignored",
-			fairnessID: "",
-			headers:    map[string]string{},
-			body: &fwkrh.InferenceRequestBody{
-				Payload: fwkrh.PayloadMap{"previous_response_id": "resp-456"},
-			},
-			wantFairnessID: "",
+			name:          "previous_response_id in body is ignored",
+			headers:       map[string]string{},
+			body:          &fwkrh.InferenceRequestBody{Payload: fwkrh.PayloadMap{"previous_response_id": "resp-456"}},
+			wantAttrFound: false,
 		},
 		{
-			name:           "nil body does not panic",
-			fairnessID:     "",
-			headers:        map[string]string{},
-			body:           nil,
-			wantFairnessID: "",
+			name:          "nil body does not panic",
+			headers:       map[string]string{},
+			body:          nil,
+			wantAttrFound: false,
 		},
 		{
-			name:           "no matching headers leaves fairness ID empty",
-			fairnessID:     "",
-			headers:        map[string]string{"x-unrelated": "value"},
-			wantFairnessID: "",
+			name:          "no matching headers leaves no attribute",
+			headers:       map[string]string{"x-unrelated": "value"},
+			wantAttrFound: false,
 		},
 		{
-			name:           "empty headers leaves fairness ID empty",
-			fairnessID:     "",
-			headers:        map[string]string{},
-			wantFairnessID: "",
+			name:          "empty headers leaves no attribute",
+			headers:       map[string]string{},
+			wantAttrFound: false,
 		},
 		{
-			name:           "nil headers does not panic",
-			fairnessID:     "",
-			headers:        nil,
-			wantFairnessID: "",
+			name:          "nil headers does not panic",
+			headers:       nil,
+			wantAttrFound: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := &scheduling.InferenceRequest{
-				FairnessID: tt.fairnessID,
-				Headers:    tt.headers,
-				Body:       tt.body,
+				Headers: tt.headers,
+				Body:    tt.body,
 			}
-			err := p.PreAdmit(context.Background(), req)
+			err := p.RequestHeader(context.Background(), req)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if req.FairnessID != tt.wantFairnessID {
-				t.Errorf("FairnessID = %q, want %q", req.FairnessID, tt.wantFairnessID)
+			got, ok := scheduling.ReadRequestAttribute[string](req, AgentIdentityKey)
+			if ok != tt.wantAttrFound {
+				t.Errorf("attribute found = %v, want %v", ok, tt.wantAttrFound)
+			}
+			if ok && got != tt.wantIdentity {
+				t.Errorf("agent identity = %q, want %q", got, tt.wantIdentity)
+			}
+			// FairnessID must never be set by the plugin.
+			if req.FairnessID != "" {
+				t.Errorf("FairnessID = %q, want empty (plugin must not set FairnessID)", req.FairnessID)
 			}
 		})
 	}
@@ -214,9 +208,9 @@ func TestPluginFactory_PriorityHeaders(t *testing.T) {
 	}
 }
 
-// TestPreAdmit_CustomHeader proves end-to-end that a header added
+// TestRequestHeader_CustomHeader proves end-to-end that a header added
 // via additionalSessionHeaders is honored at request time.
-func TestPreAdmit_CustomHeader(t *testing.T) {
+func TestRequestHeader_CustomHeader(t *testing.T) {
 	pi, err := PluginFactory("test",
 		fwkplugin.StrictDecoder(json.RawMessage(`{"additionalSessionHeaders":["x-tenant-id"]}`)), nil)
 	if err != nil {
@@ -227,11 +221,15 @@ func TestPreAdmit_CustomHeader(t *testing.T) {
 	req := &scheduling.InferenceRequest{
 		Headers: map[string]string{"x-tenant-id": "tenant-42"},
 	}
-	if err := p.PreAdmit(context.Background(), req); err != nil {
-		t.Fatalf("PreAdmit: %v", err)
+	if err := p.RequestHeader(context.Background(), req); err != nil {
+		t.Fatalf("RequestHeader: %v", err)
 	}
-	if req.FairnessID != "tenant-42" {
-		t.Errorf("FairnessID = %q, want %q", req.FairnessID, "tenant-42")
+	got, ok := scheduling.ReadRequestAttribute[string](req, AgentIdentityKey)
+	if !ok {
+		t.Fatal("agent-identity attribute not found")
+	}
+	if got != "tenant-42" {
+		t.Errorf("agent identity = %q, want %q", got, "tenant-42")
 	}
 
 	// And it wins over a default-bucket header (because it is prepended).
@@ -241,10 +239,14 @@ func TestPreAdmit_CustomHeader(t *testing.T) {
 			ClaudeCodeSessionHeader: "claude-session",
 		},
 	}
-	if err := p.PreAdmit(context.Background(), req2); err != nil {
-		t.Fatalf("PreAdmit: %v", err)
+	if err := p.RequestHeader(context.Background(), req2); err != nil {
+		t.Fatalf("RequestHeader: %v", err)
 	}
-	if req2.FairnessID != "tenant-42" {
-		t.Errorf("FairnessID = %q, want %q (custom should win)", req2.FairnessID, "tenant-42")
+	got2, ok2 := scheduling.ReadRequestAttribute[string](req2, AgentIdentityKey)
+	if !ok2 {
+		t.Fatal("agent-identity attribute not found")
+	}
+	if got2 != "tenant-42" {
+		t.Errorf("agent identity = %q, want %q (custom should win)", got2, "tenant-42")
 	}
 }

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic.go
@@ -43,7 +43,10 @@ const (
 )
 
 // compile-time type validation
-var _ fwkrh.Parser = &AnthropicParser{}
+var (
+	_ fwkrh.Parser            = &AnthropicParser{}
+	_ fwkrh.ModelNameRewriter = &AnthropicParser{}
+)
 
 type AnthropicParser struct {
 	typedName fwkplugin.TypedName
@@ -112,11 +115,24 @@ func (p *AnthropicParser) ParseRequest(_ context.Context, body []byte, headers m
 		Payload:         fwkrh.PayloadMap(bodyMap),
 		MaxOutputTokens: fwkrh.MaxOutputTokensFromPayload(bodyMap, "max_tokens"),
 	}
+	if model, ok := bodyMap["model"].(string); ok {
+		result.Model = model
+	}
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		result.Stream = true
 	}
 
 	return &fwkrh.ParseResult{Body: result, SkipResponseProcessing: false}, nil
+}
+
+// RewriteModelName writes the resolved model into the request payload map.
+func (p *AnthropicParser) RewriteModelName(payload fwkrh.MarshalablePayload, model string) (fwkrh.MarshalablePayload, error) {
+	m, ok := payload.(fwkrh.PayloadMap)
+	if !ok {
+		return payload, nil
+	}
+	m["model"] = model
+	return m, nil
 }
 
 func (p *AnthropicParser) ParseResponse(_ context.Context, body []byte, headers map[string]string, _ bool) (*fwkrh.ParsedResponse, error) {

--- a/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/anthropic/anthropic_test.go
@@ -446,6 +446,9 @@ func TestAnthropicParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 
+			// Model is extracted from the request body's "model" field.
+			tt.want.Model, _ = tt.body["model"].(string)
+
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai.go
@@ -61,7 +61,10 @@ const (
 )
 
 // compile-time type validation
-var _ fwkrh.Parser = &OpenAIParser{}
+var (
+	_ fwkrh.Parser            = &OpenAIParser{}
+	_ fwkrh.ModelNameRewriter = &OpenAIParser{}
+)
 
 // OpenAIParser implements the fwkrh.Parser interface for OpenAI API
 // https://developers.openai.com/api/reference/overview
@@ -121,11 +124,24 @@ func (p *OpenAIParser) ParseRequest(ctx context.Context, body []byte, headers ma
 		return nil, err
 	}
 	extractedBody.Payload = fwkrh.PayloadMap(bodyMap)
+	if model, ok := bodyMap["model"].(string); ok {
+		extractedBody.Model = model
+	}
 	extractedBody.MaxOutputTokens = maxOutputTokensForAPI(apiType, bodyMap)
 	if stream, ok := bodyMap["stream"].(bool); ok && stream {
 		extractedBody.Stream = true
 	}
 	return &fwkrh.ParseResult{Body: extractedBody, SkipResponseProcessing: false}, nil
+}
+
+// RewriteModelName writes the resolved model into the request payload map.
+func (p *OpenAIParser) RewriteModelName(payload fwkrh.MarshalablePayload, model string) (fwkrh.MarshalablePayload, error) {
+	m, ok := payload.(fwkrh.PayloadMap)
+	if !ok {
+		return payload, nil
+	}
+	m["model"] = model
+	return m, nil
 }
 
 // maxOutputTokensForAPI normalizes the per-API output-token cap field into a

--- a/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/openai/openai_test.go
@@ -1055,6 +1055,9 @@ func TestOpenAIParser_ParseRequest(t *testing.T) {
 				t.Errorf("ParseRequest() got.SkipResponseProcessing = %v, want false", got.SkipResponseProcessing)
 			}
 
+			// Model is extracted from the request body's "model" field.
+			tt.want.Model, _ = tt.body["model"].(string)
+
 			if diff := cmp.Diff(tt.want, got.Body); diff != "" {
 				t.Errorf("ParseRequest() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
+++ b/pkg/epp/framework/plugins/requesthandling/parsers/vllmhttp/vllmhttp.go
@@ -43,7 +43,10 @@ const (
 )
 
 // compile-time type validation
-var _ fwkrh.Parser = &VllmHTTPParser{}
+var (
+	_ fwkrh.Parser            = &VllmHTTPParser{}
+	_ fwkrh.ModelNameRewriter = &VllmHTTPParser{}
+)
 
 // VllmHTTPParser implements fwkrh.Parser for vLLM HTTP endpoints. It handles
 // /inference/v1/generate and delegates response parsing to an embedded
@@ -102,6 +105,11 @@ func (p *VllmHTTPParser) ParseResponse(ctx context.Context, body []byte, headers
 	return p.openai.ParseResponse(ctx, body, headers, isStreaming)
 }
 
+// RewriteModelName delegates to the OpenAI parser; the generate body shares the payload map format.
+func (p *VllmHTTPParser) RewriteModelName(payload fwkrh.MarshalablePayload, model string) (fwkrh.MarshalablePayload, error) {
+	return p.openai.RewriteModelName(payload, model)
+}
+
 // parseGenerateRequest decodes a /inference/v1/generate body into an
 // InferenceRequestBody. Token IDs are required; everything else is optional.
 func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResult, error) {
@@ -121,6 +129,9 @@ func (p *VllmHTTPParser) parseGenerateRequest(rawBody []byte) (*fwkrh.ParseResul
 	body := &fwkrh.InferenceRequestBody{
 		Generate: &generate,
 		Payload:  fwkrh.PayloadMap(bodyMap),
+	}
+	if model, ok := bodyMap["model"].(string); ok {
+		body.Model = model
 	}
 	// max_tokens lives under sampling_params in the generate wire format.
 	if sp, ok := bodyMap["sampling_params"].(map[string]any); ok {

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/README.md
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/README.md
@@ -1,0 +1,65 @@
+# Endpoint Attribute Filter Plugin
+
+**Type:** `endpoint-attribute-filter`
+
+This plugin filters candidate endpoints by a single configured numeric endpoint attribute.
+
+## What it does
+
+For each scheduling cycle, the plugin reads the configured attribute (`attribute`) from each candidate endpoint and keeps only the endpoints whose value satisfies the configured algorithm. This PR supports the `threshold` algorithm; `percentile`, `topK` and `range` are planned follow-ups.
+
+With `threshold`, an endpoint is kept when
+
+\[
+\text{value(endpoint)} \ \langle op \rangle\ \text{threshold.value}
+\]
+
+is true for the configured `threshold.operator`.
+
+Policies for the awkward cases:
+
+- **`onMissing`** — what happens to an endpoint that does not have the attribute: `Pass` keeps it (the default), `Fail` drops it.
+- **`fallbackOnEmpty`** — when every endpoint is filtered out and this is `true`, the original candidate list is returned unchanged, so the request can still be routed somewhere. Default `false`.
+
+The attribute is expected to be a numeric custom metric produced by the core metrics extractor (see the [metrics extractor](../../../datalayer/extractor/metrics/README.md)), stored as a `ScalarMetricValue` endpoint attribute.
+
+## Inputs consumed
+
+The plugin consumes:
+
+- the configured `attribute` (`ScalarMetricValue`)
+
+## Configuration
+
+| Parameter                       | Required | Description                                                                              |
+|---------------------------------|----------|------------------------------------------------------------------------------------------|
+| `attribute`                     | yes      | Endpoint attribute to read, e.g. `num_requests_running`.                                  |
+| `onMissing`                     | no       | `Pass` (default) or `Fail` — keep or drop endpoints missing the attribute.                |
+| `fallbackOnEmpty`               | no       | When `true`, return the unfiltered candidates if every endpoint was dropped. Default `false`. |
+| `algorithm.type`                | yes      | Only `threshold` is currently supported.                                                  |
+| `algorithm.threshold.operator`  | yes      | `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `Equal` or `NotEqual`. |
+| `algorithm.threshold.value`     | yes      | The value compared against the endpoint's attribute.                                      |
+
+**Configuration Example:**
+```yaml
+plugins:
+  - type: endpoint-attribute-filter
+    name: drop-loaded-endpoints
+    parameters:
+      attribute: "num_requests_running"
+      onMissing: "Pass"
+      fallbackOnEmpty: true
+      algorithm:
+        type: "threshold"
+        threshold:
+          operator: "LessThan"
+          value: 10
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: drop-loaded-endpoints
+```
+
+## See also
+
+The `endpoint-attribute-scorer` plugin ([llm-d/llm-d-router#1620](https://github.com/llm-d/llm-d-router/pull/1620)) is the scoring counterpart of this filter: instead of dropping endpoints, it ranks them by the same kind of configured attribute.

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/doc.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package endpointattribute provides a generic filter plugin that filters
+// candidate endpoints by a single configured numeric endpoint attribute.
+package endpointattribute

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointattribute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/plugin"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const (
+	// EndpointAttributeFilterType is the type of the EndpointAttributeFilter.
+	EndpointAttributeFilterType = "endpoint-attribute-filter"
+
+	onMissingPass = "Pass"
+	onMissingFail = "Fail"
+
+	algorithmThreshold = "threshold"
+
+	operatorLessThan           = "LessThan"
+	operatorLessThanOrEqual    = "LessThanOrEqual"
+	operatorGreaterThan        = "GreaterThan"
+	operatorGreaterThanOrEqual = "GreaterThanOrEqual"
+	operatorEqual              = "Equal"
+	operatorNotEqual           = "NotEqual"
+)
+
+// thresholdParameters keeps endpoints whose attribute value compares true
+// against the configured value.
+type thresholdParameters struct {
+	Operator string  `json:"operator"`
+	Value    float64 `json:"value"`
+}
+
+// algorithmParameters selects the filtering algorithm. threshold is the only
+// algorithm currently supported; percentile, topK and range are planned as
+// follow-ups.
+type algorithmParameters struct {
+	Type      string               `json:"type"`
+	Threshold *thresholdParameters `json:"threshold,omitempty"`
+}
+
+type parameters struct {
+	Attribute string `json:"attribute"`
+	// OnMissing decides what happens to endpoints that do not have the
+	// attribute: "Pass" keeps them (the default), "Fail" drops them.
+	OnMissing string `json:"onMissing"`
+	// FallbackOnEmpty returns the unfiltered candidates when every endpoint
+	// was filtered out, so the request can still be routed somewhere.
+	FallbackOnEmpty bool                `json:"fallbackOnEmpty"`
+	Algorithm       algorithmParameters `json:"algorithm"`
+}
+
+// compile-time type assertion
+var _ scheduling.Filter = &EndpointAttributeFilter{}
+
+// EndpointAttributeFilterFactory defines the factory function for EndpointAttributeFilter.
+func EndpointAttributeFilterFactory(name string, rawParameters *json.Decoder, _ plugin.Handle) (plugin.Plugin, error) {
+	var params parameters
+	if rawParameters != nil {
+		if err := rawParameters.Decode(&params); err != nil {
+			return nil, fmt.Errorf("failed to parse the parameters of the '%s' filter - %w", EndpointAttributeFilterType, err)
+		}
+	}
+
+	return NewEndpointAttributeFilter(name, params)
+}
+
+// NewEndpointAttributeFilter validates the given parameters and returns a new
+// EndpointAttributeFilter with the given name.
+func NewEndpointAttributeFilter(name string, params parameters) (*EndpointAttributeFilter, error) {
+	if name == "" {
+		name = EndpointAttributeFilterType
+	}
+	if params.Attribute == "" {
+		return nil, errors.New("endpoint attribute filter requires a non-empty attribute")
+	}
+	switch params.OnMissing {
+	case "":
+		params.OnMissing = onMissingPass
+	case onMissingPass, onMissingFail:
+	default:
+		return nil, fmt.Errorf("endpoint attribute filter onMissing must be %q or %q, got %q",
+			onMissingPass, onMissingFail, params.OnMissing)
+	}
+	if params.Algorithm.Type != algorithmThreshold {
+		return nil, fmt.Errorf("endpoint attribute filter algorithm.type must be %q, got %q",
+			algorithmThreshold, params.Algorithm.Type)
+	}
+	threshold := params.Algorithm.Threshold
+	if threshold == nil {
+		return nil, fmt.Errorf("endpoint attribute filter requires algorithm.threshold when algorithm.type is %q",
+			algorithmThreshold)
+	}
+	switch threshold.Operator {
+	case operatorLessThan, operatorLessThanOrEqual, operatorGreaterThan,
+		operatorGreaterThanOrEqual, operatorEqual, operatorNotEqual:
+	default:
+		return nil, fmt.Errorf("endpoint attribute filter threshold.operator must be one of %q, %q, %q, %q, %q, %q, got %q",
+			operatorLessThan, operatorLessThanOrEqual, operatorGreaterThan,
+			operatorGreaterThanOrEqual, operatorEqual, operatorNotEqual, threshold.Operator)
+	}
+
+	return &EndpointAttributeFilter{
+		typedName:       plugin.TypedName{Type: EndpointAttributeFilterType, Name: name},
+		attribute:       params.Attribute,
+		passOnMissing:   params.OnMissing == onMissingPass,
+		fallbackOnEmpty: params.FallbackOnEmpty,
+		threshold:       *threshold,
+	}, nil
+}
+
+// EndpointAttributeFilter filters candidate endpoints by a single configured
+// numeric endpoint attribute (produced by the custom metrics extraction
+// layer). Endpoints whose attribute value compares true against the
+// configured threshold are kept.
+type EndpointAttributeFilter struct {
+	typedName plugin.TypedName
+	attribute string
+	// passOnMissing keeps endpoints that do not have the attribute instead of
+	// dropping them.
+	passOnMissing bool
+	// fallbackOnEmpty returns the unfiltered candidates when every endpoint
+	// was filtered out.
+	fallbackOnEmpty bool
+	threshold       thresholdParameters
+}
+
+// TypedName returns the typed name of the plugin.
+func (f *EndpointAttributeFilter) TypedName() plugin.TypedName {
+	return f.typedName
+}
+
+// Consumes returns the list of data that is consumed by the plugin.
+func (f *EndpointAttributeFilter) Consumes() map[string]any {
+	return map[string]any{
+		f.attribute: attrmetrics.ScalarMetricValue(0),
+	}
+}
+
+// Filter keeps the endpoints whose attribute value satisfies the configured
+// threshold. Endpoints missing the attribute are kept or dropped according to
+// the onMissing policy. When all endpoints are filtered out and
+// fallbackOnEmpty is set, the original candidates are returned.
+func (f *EndpointAttributeFilter) Filter(_ context.Context, _ *scheduling.InferenceRequest, endpoints []scheduling.Endpoint) []scheduling.Endpoint {
+	filtered := make([]scheduling.Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		value, ok := attrmetrics.ReadScalarMetricValue(endpoint, f.attribute)
+		if !ok {
+			if f.passOnMissing {
+				filtered = append(filtered, endpoint)
+			}
+			continue
+		}
+		if f.matches(float64(value)) {
+			filtered = append(filtered, endpoint)
+		}
+	}
+
+	if len(filtered) == 0 && f.fallbackOnEmpty {
+		return endpoints
+	}
+	return filtered
+}
+
+// matches reports whether the value satisfies the configured threshold.
+func (f *EndpointAttributeFilter) matches(value float64) bool {
+	switch f.threshold.Operator {
+	case operatorLessThan:
+		return value < f.threshold.Value
+	case operatorLessThanOrEqual:
+		return value <= f.threshold.Value
+	case operatorGreaterThan:
+		return value > f.threshold.Value
+	case operatorGreaterThanOrEqual:
+		return value >= f.threshold.Value
+	case operatorEqual:
+		return value == f.threshold.Value
+	case operatorNotEqual:
+		return value != f.threshold.Value
+	default:
+		// Unreachable: the operator is validated at construction time.
+		return false
+	}
+}

--- a/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter_test.go
+++ b/pkg/epp/framework/plugins/scheduling/filter/endpointattribute/filter_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointattribute
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fwkdl "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/datalayer"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
+	attrmetrics "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/metrics"
+)
+
+const testAttribute = "num_requests_running"
+
+func TestEndpointAttributeFilterFactory(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters string
+		wantErr    string
+	}{
+		{
+			name: "valid threshold with defaulted onMissing",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "LessThan", "value": 10}}}`,
+		},
+		{
+			name: "valid threshold with explicit policies",
+			parameters: `{"attribute": "num_requests_running",
+				"onMissing": "Fail", "fallbackOnEmpty": true,
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "GreaterThanOrEqual", "value": 0.5}}}`,
+		},
+		{
+			name: "missing attribute",
+			parameters: `{"algorithm": {"type": "threshold",
+				"threshold": {"operator": "LessThan", "value": 10}}}`,
+			wantErr: "attribute",
+		},
+		{
+			name: "invalid onMissing",
+			parameters: `{"attribute": "num_requests_running", "onMissing": "Maybe",
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "LessThan", "value": 10}}}`,
+			wantErr: "onMissing",
+		},
+		{
+			name:       "missing algorithm type",
+			parameters: `{"attribute": "num_requests_running"}`,
+			wantErr:    "algorithm.type",
+		},
+		{
+			name: "unsupported algorithm type",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "percentile"}}`,
+			wantErr: "algorithm.type",
+		},
+		{
+			name: "missing threshold block",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "threshold"}}`,
+			wantErr: "algorithm.threshold",
+		},
+		{
+			name: "invalid threshold operator",
+			parameters: `{"attribute": "num_requests_running",
+				"algorithm": {"type": "threshold",
+					"threshold": {"operator": "Around", "value": 10}}}`,
+			wantErr: "threshold.operator",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := json.NewDecoder(strings.NewReader(test.parameters))
+			plugin, err := EndpointAttributeFilterFactory("test-filter", decoder, nil)
+			if test.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, EndpointAttributeFilterType, plugin.TypedName().Type)
+			assert.Equal(t, "test-filter", plugin.TypedName().Name)
+		})
+	}
+}
+
+func newEndpointWithValue(value float64) scheduling.Endpoint {
+	attrs := fwkdl.NewAttributes()
+	attrs.Put(testAttribute, attrmetrics.ScalarMetricValue(value))
+	return scheduling.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{}, attrs)
+}
+
+func newEndpointWithoutValue() scheduling.Endpoint {
+	return scheduling.NewEndpoint(&fwkdl.EndpointMetadata{}, &fwkdl.Metrics{}, nil)
+}
+
+func TestEndpointAttributeFilterFilter(t *testing.T) {
+	tests := []struct {
+		name            string
+		operator        string
+		value           float64
+		onMissing       string
+		fallbackOnEmpty bool
+		endpoints       []scheduling.Endpoint
+		wantKept        []int // indexes into endpoints expected to survive
+	}{
+		{
+			name:     "LessThan keeps values below the threshold",
+			operator: operatorLessThan,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{0},
+		},
+		{
+			name:     "LessThanOrEqual keeps the boundary value",
+			operator: operatorLessThanOrEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{0, 1},
+		},
+		{
+			name:     "GreaterThan keeps values above the threshold",
+			operator: operatorGreaterThan,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{2},
+		},
+		{
+			name:     "GreaterThanOrEqual keeps the boundary value",
+			operator: operatorGreaterThanOrEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+				newEndpointWithValue(15),
+			},
+			wantKept: []int{1, 2},
+		},
+		{
+			name:     "Equal keeps only the matching value",
+			operator: operatorEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+			},
+			wantKept: []int{1},
+		},
+		{
+			name:     "NotEqual drops the matching value",
+			operator: operatorNotEqual,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(10),
+			},
+			wantKept: []int{0},
+		},
+		{
+			name:      "missing attribute passes by default",
+			operator:  operatorLessThan,
+			value:     10,
+			onMissing: onMissingPass,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(15),
+				newEndpointWithoutValue(),
+			},
+			wantKept: []int{1},
+		},
+		{
+			name:      "missing attribute fails when onMissing is Fail",
+			operator:  operatorLessThan,
+			value:     10,
+			onMissing: onMissingFail,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithoutValue(),
+			},
+			wantKept: []int{0},
+		},
+		{
+			name:     "empty result stays empty without fallback",
+			operator: operatorLessThan,
+			value:    10,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(15),
+				newEndpointWithValue(20),
+			},
+			wantKept: []int{},
+		},
+		{
+			name:            "empty result returns all candidates with fallbackOnEmpty",
+			operator:        operatorLessThan,
+			value:           10,
+			fallbackOnEmpty: true,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(15),
+				newEndpointWithValue(20),
+			},
+			wantKept: []int{0, 1},
+		},
+		{
+			name:            "fallbackOnEmpty does not trigger when some endpoints survive",
+			operator:        operatorLessThan,
+			value:           10,
+			fallbackOnEmpty: true,
+			endpoints: []scheduling.Endpoint{
+				newEndpointWithValue(5),
+				newEndpointWithValue(20),
+			},
+			wantKept: []int{0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter, err := NewEndpointAttributeFilter("test-filter", parameters{
+				Attribute:       testAttribute,
+				OnMissing:       test.onMissing,
+				FallbackOnEmpty: test.fallbackOnEmpty,
+				Algorithm: algorithmParameters{
+					Type: algorithmThreshold,
+					Threshold: &thresholdParameters{
+						Operator: test.operator,
+						Value:    test.value,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			got := filter.Filter(context.Background(), &scheduling.InferenceRequest{}, test.endpoints)
+
+			want := make([]scheduling.Endpoint, 0, len(test.wantKept))
+			for _, i := range test.wantKept {
+				want = append(want, test.endpoints[i])
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/pkg/epp/requestcontrol/admission.go
+++ b/pkg/epp/requestcontrol/admission.go
@@ -145,8 +145,9 @@ func NewFlowControlAdmissionController(fc flowController, poolName string) *Flow
 	}
 }
 
-// Admit implements the AdmissionController interface by checking for saturation on sheddable requests first, then
-// deferring to the Flow Control system.
+// Admit implements the AdmissionController interface by deferring the admission decision to the Flow Control system
+// via EnqueueAndWait. Saturation is enforced downstream by the dispatch cycle, which gates lower-priority bands as
+// pool saturation approaches their usage limits; queued requests may be rejected on capacity or evicted on TTL expiry.
 func (fcac *FlowControlAdmissionController) Admit(
 	ctx context.Context,
 	reqCtx *handlers.RequestContext,

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -20,7 +20,6 @@ package requestcontrol
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -244,6 +243,9 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 
 	logger := log.FromContext(ctx)
 
+	// Record the client-facing model for every request, including forwarded-unchanged ones.
+	reqCtx.IncomingModelName = inferenceRequestBody.Model
+
 	err = d.modelRewriteIfNeeded(ctx, reqCtx, inferenceRequestBody)
 	if err != nil {
 		return reqCtx, err
@@ -356,45 +358,47 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 }
 
 func (d *Director) modelRewriteIfNeeded(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
-	if v, ok := inferenceRequestBody.Payload.(fwkrh.PayloadMap); ok {
-		// Mutate the model name inside the map, this is currently only supported if the payload is a PayloadMap.
-		_, err := d.mutateModel(ctx, reqCtx, v)
-		if err != nil {
-			return err
-		}
+	logger := log.FromContext(ctx)
+	rewriter, ok := reqCtx.Parser.(fwkrh.ModelNameRewriter)
+	if !ok {
+		logger.Info("Warning: parser does not implement ModelNameRewriter, skipping model rewrite")
+		return nil
 	}
-	return nil
-}
-
-func (d *Director) mutateModel(ctx context.Context, reqCtx *handlers.RequestContext, bodyMap map[string]any) (*handlers.RequestContext, error) {
-	reqCtx.IncomingModelName, _ = bodyMap["model"].(string)
+	payload, ok := inferenceRequestBody.Payload.(fwkrh.MarshalablePayload)
+	if !ok {
+		logger.Info("Warning: payload does not implement MarshalablePayload, skipping model rewrite")
+		return nil
+	}
 	if reqCtx.TargetModelName == "" {
 		reqCtx.TargetModelName = reqCtx.IncomingModelName
 	}
 	d.applyWeightedModelRewrite(ctx, reqCtx)
 	if reqCtx.TargetModelName == "" {
-		return reqCtx, errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
+		return errcommon.Error{Code: errcommon.BadRequest, Msg: "model not found in request body"}
 	}
-	bodyMap["model"] = reqCtx.TargetModelName
-	return reqCtx, nil
+	mutated, err := rewriter.RewriteModelName(payload, reqCtx.TargetModelName)
+	if err != nil {
+		return err
+	}
+	// Store the result back so repackage serializes the mutated payload.
+	inferenceRequestBody.Payload = mutated
+	return nil
 }
 
 func (d *Director) repackage(ctx context.Context, reqCtx *handlers.RequestContext, inferenceRequestBody *fwkrh.InferenceRequestBody) error {
-	logger := log.FromContext(ctx)
-	switch v := inferenceRequestBody.Payload.(type) {
-	case fwkrh.PayloadMap:
-		requestBodyBytes, err := json.Marshal(v)
-		if err != nil {
-			logger.Error(err, "Error marshalling request body")
-			return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
-		}
-		reqCtx.Request.RawBody = requestBodyBytes
-		reqCtx.RequestSize = len(requestBodyBytes)
-	case fwkrh.PayloadProto, fwkrh.RawPayload:
+	marshaler, ok := inferenceRequestBody.Payload.(fwkrh.Marshaler)
+	if !ok {
+		// Payload forwarded unchanged (raw or proto).
 		reqCtx.RequestSize = len(reqCtx.Request.RawBody)
-	default:
-		return errcommon.Error{Code: errcommon.BadRequest, Msg: "Unsupported llmRequest parsedBody"}
+		return nil
 	}
+	requestBodyBytes, err := marshaler.Marshal()
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Error marshalling request body")
+		return errcommon.Error{Code: errcommon.Internal, Msg: "Error marshalling request body"}
+	}
+	reqCtx.Request.RawBody = requestBodyBytes
+	reqCtx.RequestSize = len(requestBodyBytes)
 	return nil
 }
 

--- a/pkg/epp/requestcontrol/director.go
+++ b/pkg/epp/requestcontrol/director.go
@@ -48,6 +48,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
 	"github.com/llm-d/llm-d-router/pkg/epp/handlers"
 	"github.com/llm-d/llm-d-router/pkg/epp/metadata"
 	"github.com/llm-d/llm-d-router/pkg/epp/metrics"
@@ -278,11 +279,16 @@ func (d *Director) HandleRequest(ctx context.Context, reqCtx *handlers.RequestCo
 	ctx = log.IntoContext(ctx, logger)
 	logger.V(logutil.DEBUG).Info("LLM request assembled")
 
-	if err := d.runPreAdmissionPlugins(ctx, reqCtx.SchedulingRequest); err != nil {
+	if err := d.runRequestHeaderProcessors(ctx, reqCtx.SchedulingRequest); err != nil {
 		return reqCtx, err
 	}
+	// Derive FairnessID from agent-identity attribute if not already set by explicit header.
 	if reqCtx.SchedulingRequest.FairnessID == "" {
-		reqCtx.SchedulingRequest.FairnessID = metadata.DefaultFairnessID
+		if agentID, ok := fwksched.ReadRequestAttribute[string](reqCtx.SchedulingRequest, agentidentity.AgentIdentityKey); ok && agentID != "" {
+			reqCtx.SchedulingRequest.FairnessID = agentID
+		} else {
+			reqCtx.SchedulingRequest.FairnessID = metadata.DefaultFairnessID
+		}
 	}
 
 	// Admit may block until flow control admits the request.
@@ -594,19 +600,19 @@ func (d *Director) runPreRequestPlugins(ctx context.Context, request *fwksched.I
 	}
 }
 
-func (d *Director) runPreAdmissionPlugins(ctx context.Context, request *fwksched.InferenceRequest) error {
-	if len(d.requestControlPlugins.preAdmissionPlugins) == 0 {
+func (d *Director) runRequestHeaderProcessors(ctx context.Context, request *fwksched.InferenceRequest) error {
+	if len(d.requestControlPlugins.requestHeaderPlugins) == 0 {
 		return nil
 	}
 	loggerDebug := log.FromContext(ctx).V(logutil.DEBUG)
-	for _, plugin := range d.requestControlPlugins.preAdmissionPlugins {
-		loggerDebug.Info("Running PreAdmitter plugin", "plugin", plugin.TypedName())
+	for _, plugin := range d.requestControlPlugins.requestHeaderPlugins {
+		loggerDebug.Info("Running RequestHeaderProcessor plugin", "plugin", plugin.TypedName())
 		before := time.Now()
-		if err := plugin.PreAdmit(ctx, request); err != nil {
+		if err := plugin.RequestHeader(ctx, request); err != nil {
 			return err
 		}
-		metrics.RecordPluginProcessingLatency(fwkrc.PreAdmissionExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
-		loggerDebug.Info("Completed running PreAdmitter plugin successfully", "plugin", plugin.TypedName())
+		metrics.RecordPluginProcessingLatency(fwkrc.RequestHeaderExtensionPoint, plugin.TypedName().Type, plugin.TypedName().Name, time.Since(before))
+		loggerDebug.Info("Completed running RequestHeaderProcessor plugin successfully", "plugin", plugin.TypedName())
 	}
 	return nil
 }

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -887,7 +887,8 @@ func TestDirector_HandleRequest(t *testing.T) {
 					reqCtx.Request.Headers[metadata.FlowFairnessIDKey] = test.fairnessIDHeader
 				}
 
-				parseResult, parseErr := openai.NewOpenAIParser().ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+				reqCtx.Parser = openai.NewOpenAIParser()
+				parseResult, parseErr := reqCtx.Parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 				var returnedReqCtx *handlers.RequestContext
 				if parseErr != nil {
 					err = errcommon.Error{Code: errcommon.BadRequest, Msg: parseErr.Error()}
@@ -1898,7 +1899,8 @@ func TestDirector_HandleRequest_ConditionalDecode(t *testing.T) {
 			require.NoError(t, err)
 			reqCtx.Request.RawBody = body
 
-			parseResult, err := openai.NewOpenAIParser().ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
+			reqCtx.Parser = openai.NewOpenAIParser()
+			parseResult, err := reqCtx.Parser.ParseRequest(ctx, reqCtx.Request.RawBody, reqCtx.Request.Headers)
 			require.NoError(t, err)
 
 			_, err = dir.HandleRequest(ctx, reqCtx, parseResult.Body)

--- a/pkg/epp/requestcontrol/director_test.go
+++ b/pkg/epp/requestcontrol/director_test.go
@@ -54,6 +54,7 @@ import (
 	fwkrh "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/requesthandling"
 	fwksched "github.com/llm-d/llm-d-router/pkg/epp/framework/interface/scheduling"
 	attrprefix "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/datalayer/attribute/prefix"
+	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requestcontrol/requestheader/agentidentity"
 	"github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/requesthandling/parsers/openai"
 	sessionaffinityfilter "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/filter/sessionaffinity"
 	sessionaffinityscorer "github.com/llm-d/llm-d-router/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity"
@@ -164,6 +165,21 @@ func (m *mockAdmissionPlugin) TypedName() fwkplugin.TypedName {
 
 func (m *mockAdmissionPlugin) Admit(ctx context.Context, request *fwksched.InferenceRequest, endpoints []fwksched.Endpoint) error {
 	return m.denialError
+}
+
+type mockRequestHeaderPlugin struct {
+	name           string
+	attributeKey   string
+	attributeValue string
+}
+
+func (m *mockRequestHeaderPlugin) TypedName() fwkplugin.TypedName {
+	return fwkplugin.TypedName{Name: m.name, Type: "mock-request-header"}
+}
+
+func (m *mockRequestHeaderPlugin) RequestHeader(_ context.Context, request *fwksched.InferenceRequest) error {
+	request.PutAttribute(m.attributeKey, m.attributeValue)
+	return nil
 }
 
 type mockPreRequestPlugin struct {
@@ -363,6 +379,7 @@ func TestDirector_HandleRequest(t *testing.T) {
 		admitRequestDenialError error                    // Expected denial error from admission plugin
 		dataProducerPlugin      *mockDataProducerPlugin
 		preRequestPlugin        *mockPreRequestPlugin
+		requestHeaderPlugin     *mockRequestHeaderPlugin
 		wantMutatedBody         map[string]any
 		fairnessIDHeader        string // If non-empty, set as metadata.FlowFairnessIDKey on the incoming request.
 		wantFairnessID          string // If non-empty, asserted against returnedReqCtx.SchedulingRequest.FairnessID.
@@ -424,6 +441,45 @@ func TestDirector_HandleRequest(t *testing.T) {
 			initialTargetModelName: model,
 			inferenceObjectiveName: objectiveName,
 			wantFairnessID:         metadata.DefaultFairnessID,
+		},
+		{
+			name: "fairness ID derived from agent-identity attribute",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			inferenceObjectiveName: objectiveName,
+			requestHeaderPlugin: &mockRequestHeaderPlugin{
+				name:           "agent-identity",
+				attributeKey:   agentidentity.AgentIdentityKey,
+				attributeValue: "session-abc",
+			},
+			wantFairnessID: "session-abc",
+		},
+		{
+			name: "explicit fairness header takes precedence over agent-identity attribute",
+			reqBodyMap: map[string]any{
+				"model":  model,
+				"prompt": "critical prompt",
+			},
+			mockAdmissionController: &mockAdmissionController{admitErr: nil},
+			schedulerMockSetup: func(m *mockScheduler) {
+				m.scheduleResults = defaultSuccessfulScheduleResults
+			},
+			initialTargetModelName: model,
+			inferenceObjectiveName: objectiveName,
+			fairnessIDHeader:       "explicit-id",
+			requestHeaderPlugin: &mockRequestHeaderPlugin{
+				name:           "agent-identity",
+				attributeKey:   agentidentity.AgentIdentityKey,
+				attributeValue: "session-abc",
+			},
+			wantFairnessID: "explicit-id",
 		},
 		{
 			name: "successful request with preRequest plugin adding key",
@@ -847,6 +903,9 @@ func TestDirector_HandleRequest(t *testing.T) {
 				}
 				if test.preRequestPlugin != nil {
 					config = config.WithPreRequestPlugins(test.preRequestPlugin)
+				}
+				if test.requestHeaderPlugin != nil {
+					config = config.WithRequestHeaderPlugins(test.requestHeaderPlugin)
 				}
 				config = config.WithAdmissionPlugins(newMockAdmissionPlugin("test-admit-plugin", test.admitRequestDenialError))
 

--- a/pkg/epp/requestcontrol/request_control_config.go
+++ b/pkg/epp/requestcontrol/request_control_config.go
@@ -24,7 +24,7 @@ import (
 // NewConfig creates a new Config object and returns its pointer.
 func NewConfig() *Config {
 	return &Config{
-		preAdmissionPlugins:      []fwkrc.PreAdmitter{},
+		requestHeaderPlugins:     []fwkrc.RequestHeaderProcessor{},
 		admissionPlugins:         []fwkrc.Admitter{},
 		dataProducerPlugins:      []fwkrc.DataProducer{},
 		preRequestPlugins:        []fwkrc.PreRequest{},
@@ -35,7 +35,7 @@ func NewConfig() *Config {
 
 // Config provides a configuration for the requestcontrol plugins.
 type Config struct {
-	preAdmissionPlugins      []fwkrc.PreAdmitter
+	requestHeaderPlugins     []fwkrc.RequestHeaderProcessor
 	admissionPlugins         []fwkrc.Admitter
 	dataProducerPlugins      []fwkrc.DataProducer
 	preRequestPlugins        []fwkrc.PreRequest
@@ -43,9 +43,9 @@ type Config struct {
 	responseStreamingPlugins []fwkrc.ResponseBodyProcessor
 }
 
-// WithPreAdmissionPlugins sets the given plugins as the PreAdmitter plugins.
-func (c *Config) WithPreAdmissionPlugins(plugins ...fwkrc.PreAdmitter) *Config {
-	c.preAdmissionPlugins = plugins
+// WithRequestHeaderPlugins sets the given plugins as the RequestHeaderProcessor plugins.
+func (c *Config) WithRequestHeaderPlugins(plugins ...fwkrc.RequestHeaderProcessor) *Config {
+	c.requestHeaderPlugins = plugins
 	return c
 }
 
@@ -87,8 +87,8 @@ func (c *Config) WithAdmissionPlugins(plugins ...fwkrc.Admitter) *Config {
 // If a plugin implements multiple plugin interfaces, it will be added to each corresponding list.
 func (c *Config) AddPlugins(pluginObjects ...plugin.Plugin) {
 	for _, plugin := range pluginObjects {
-		if preAdmissionProcessor, ok := plugin.(fwkrc.PreAdmitter); ok {
-			c.preAdmissionPlugins = append(c.preAdmissionPlugins, preAdmissionProcessor)
+		if requestHeaderProcessor, ok := plugin.(fwkrc.RequestHeaderProcessor); ok {
+			c.requestHeaderPlugins = append(c.requestHeaderPlugins, requestHeaderProcessor)
 		}
 		if preRequestPlugin, ok := plugin.(fwkrc.PreRequest); ok {
 			c.preRequestPlugins = append(c.preRequestPlugins, preRequestPlugin)

--- a/pkg/epp/server/metrics_tls_test.go
+++ b/pkg/epp/server/metrics_tls_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// writeCAFile writes a self-signed CA cert to a temp file and returns its path.
+func writeCAFile(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	return path
+}
+
+func TestConfigureMetricsTLS(t *testing.T) {
+	validCA := writeCAFile(t)
+	badPEM := filepath.Join(t.TempDir(), "bad.crt")
+	require.NoError(t, os.WriteFile(badPEM, []byte("not a pem"), 0o600))
+
+	tests := []struct {
+		name           string
+		certDir        string
+		clientCA       string
+		wantErr        error
+		wantSecure     bool
+		wantClientAuth bool
+	}{
+		{name: "neither"},
+		{name: "cert dir only", certDir: "/etc/tls", wantSecure: true},
+		{name: "mTLS", certDir: "/etc/tls", clientCA: validCA, wantSecure: true, wantClientAuth: true},
+		{name: "missing CA file", clientCA: filepath.Join(t.TempDir(), "nope"), wantErr: errReadMetricsClientCA},
+		{name: "invalid CA PEM", clientCA: badPEM, wantErr: errNoValidMetricsCA},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &Options{MetricsCertDir: tc.certDir, MetricsClientCAFile: tc.clientCA}
+			mo := &metricsserver.Options{}
+			err := ConfigureMetricsTLS(opts, mo)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSecure, mo.SecureServing)
+			if tc.certDir != "" {
+				require.Equal(t, tc.certDir, mo.CertDir)
+			}
+			if !tc.wantSecure {
+				require.Empty(t, mo.TLSOpts)
+				return
+			}
+			require.Len(t, mo.TLSOpts, 1)
+			cfg := &tls.Config{}
+			mo.TLSOpts[0](cfg)
+			require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+			if tc.wantClientAuth {
+				require.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+				require.NotNil(t, cfg.ClientCAs)
+			} else {
+				require.Equal(t, tls.NoClientCert, cfg.ClientAuth)
+				require.Nil(t, cfg.ClientCAs)
+			}
+		})
+	}
+}

--- a/pkg/epp/server/options.go
+++ b/pkg/epp/server/options.go
@@ -17,9 +17,13 @@ limitations under the License.
 package server
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -27,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/llm-d/llm-d-router/pkg/common/observability/logging"
 	"github.com/llm-d/llm-d-router/pkg/common/routing"
@@ -102,6 +107,8 @@ type Options struct {
 	EnableCertReload        bool   // Enables certificate reloading of the certificates specified in --cert-path.
 	SecureServing           bool   // Enables secure serving.
 	MetricsEndpointAuth     bool   // Enables authentication and authorization of the metrics endpoint.
+	MetricsClientCAFile     string // PEM CA that requires a verified client cert on the metrics endpoint.
+	MetricsCertDir          string // Directory with the metrics server certificates that enables metrics TLS.
 	EnableGRPCStreamMetrics bool   // Enables ext_proc gRPC stream metrics (in-flight gauge, hold duration, completions counter by code).
 	//
 	// Configuration.
@@ -208,6 +215,10 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&opts.SecureServing, "secure-serving", opts.SecureServing, "Enables secure serving.")
 	fs.BoolVar(&opts.MetricsEndpointAuth, "metrics-endpoint-auth", opts.MetricsEndpointAuth,
 		"Enables authentication and authorization of the metrics endpoint.")
+	fs.StringVar(&opts.MetricsClientCAFile, "metrics-client-ca-file", opts.MetricsClientCAFile,
+		"PEM CA for metrics mTLS: require verified client certs.")
+	fs.StringVar(&opts.MetricsCertDir, "metrics-cert-dir", opts.MetricsCertDir,
+		"Directory with the metrics server certificates. Enables TLS on the metrics endpoint.")
 	fs.StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "The path to the configuration file.")
 	fs.StringVar(&opts.ConfigText, "config-text", opts.ConfigText, "The configuration specified as text, in lieu of a file.")
 }
@@ -260,8 +271,60 @@ func (opts *Options) Complete() error {
 		opts.GRPCMaxSendMsgSize = int(val)
 	}
 
+	if opts.MetricsClientCAFile != "" {
+		if _, err := os.Stat(opts.MetricsClientCAFile); err != nil {
+			return fmt.Errorf("%w: %s: %v", errMetricsCertUnreadable, opts.MetricsClientCAFile, err)
+		}
+	}
+	if opts.MetricsCertDir != "" {
+		for _, name := range []string{"tls.crt", "tls.key"} {
+			p := filepath.Join(opts.MetricsCertDir, name)
+			if _, err := os.Stat(p); err != nil {
+				return fmt.Errorf("%w: %s: %v", errMetricsCertUnreadable, p, err)
+			}
+		}
+	}
+
 	// Complete logging options.
 	return opts.LoggingOptions.Complete()
+}
+
+var (
+	errMetricsClientCARequiresCertDir = errors.New(`"metrics-client-ca-file" requires "metrics-cert-dir"`)
+	errMetricsTLSWithoutAuth          = errors.New(`"metrics-cert-dir" enables metrics TLS without authentication; set "metrics-client-ca-file" or "metrics-endpoint-auth"`)
+	errMetricsCertUnreadable          = errors.New("metrics TLS cert file unreadable")
+	errReadMetricsClientCA            = errors.New("reading metrics client CA")
+	errNoValidMetricsCA               = errors.New("no valid CA certs in metrics client CA file")
+)
+
+// ConfigureMetricsTLS enables TLS, and optional client mTLS, on the metrics server.
+func ConfigureMetricsTLS(opts *Options, mo *metricsserver.Options) error {
+	if opts.MetricsCertDir == "" && opts.MetricsClientCAFile == "" {
+		return nil
+	}
+	mo.SecureServing = true
+	if opts.MetricsCertDir != "" {
+		mo.CertDir = opts.MetricsCertDir
+	}
+	var clientCAs *x509.CertPool
+	if opts.MetricsClientCAFile != "" {
+		caPEM, err := os.ReadFile(opts.MetricsClientCAFile)
+		if err != nil {
+			return fmt.Errorf("%w %s: %v", errReadMetricsClientCA, opts.MetricsClientCAFile, err)
+		}
+		clientCAs = x509.NewCertPool()
+		if !clientCAs.AppendCertsFromPEM(caPEM) {
+			return fmt.Errorf("%w: %s", errNoValidMetricsCA, opts.MetricsClientCAFile)
+		}
+	}
+	mo.TLSOpts = append(mo.TLSOpts, func(c *tls.Config) {
+		c.MinVersion = tls.VersionTLS12
+		if clientCAs != nil {
+			c.ClientCAs = clientCAs
+			c.ClientAuth = tls.RequireAndVerifyClientCert
+		}
+	})
+	return nil
 }
 
 func (opts *Options) Validate() error {
@@ -281,6 +344,13 @@ func (opts *Options) Validate() error {
 
 	if opts.ConfigText != "" && opts.ConfigFile != "" {
 		return fmt.Errorf("both the %q and %q flags cannot be set at the same time", "config-file", "config-text")
+	}
+
+	if opts.MetricsClientCAFile != "" && opts.MetricsCertDir == "" {
+		return errMetricsClientCARequiresCertDir
+	}
+	if opts.MetricsCertDir != "" && opts.MetricsClientCAFile == "" && !opts.MetricsEndpointAuth {
+		return errMetricsTLSWithoutAuth
 	}
 
 	if opts.GRPCMaxRecvMsgSize < 0 {

--- a/pkg/epp/server/options_test.go
+++ b/pkg/epp/server/options_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package server
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPoolName   = "test-pool"
+	testConfigFile = "fake-config.yaml"
 )
 
 // TestEndpointTargetPorts
@@ -90,7 +98,7 @@ func TestEndpointTargetPorts(t *testing.T) {
 			opts.AddFlags(tt.fs)
 
 			argv := make([]string, 0, 4+len(tt.args))
-			argv = append(argv, "--endpoint-selector", "app=vllm", "--config-file", "fake-config.yaml") // avoid an options validation error
+			argv = append(argv, "--endpoint-selector", "app=vllm", "--config-file", testConfigFile) // avoid an options validation error
 			argv = append(argv, tt.args...)
 
 			if err := tt.fs.Parse(argv); err != nil {
@@ -201,7 +209,7 @@ func TestGRPCFlags(t *testing.T) {
 			opts.AddFlags(fs)
 
 			argv := make([]string, 0, 4+len(tt.args))
-			argv = append(argv, "--pool-name", "test-pool", "--config-file", "fake-config.yaml")
+			argv = append(argv, "--pool-name", testPoolName, "--config-file", testConfigFile)
 			argv = append(argv, tt.args...)
 
 			if err := fs.Parse(argv); err != nil {
@@ -235,14 +243,14 @@ func TestGRPCFlags(t *testing.T) {
 
 func TestValidateDirectValues(t *testing.T) {
 	opts := NewOptions()
-	opts.PoolName = "test-pool" // bypass other validations
+	opts.PoolName = testPoolName // bypass other validations
 	opts.GRPCMaxRecvMsgSize = -5
 	if err := opts.Validate(); err == nil {
 		t.Errorf("Expected Validate() to fail for negative GRPCMaxRecvMsgSize, but it succeeded")
 	}
 
 	opts = NewOptions()
-	opts.PoolName = "test-pool"
+	opts.PoolName = testPoolName
 	opts.GRPCMaxSendMsgSize = -5
 	if err := opts.Validate(); err == nil {
 		t.Errorf("Expected Validate() to fail for negative GRPCMaxSendMsgSize, but it succeeded")
@@ -272,7 +280,7 @@ func TestDrainTimeoutFlag(t *testing.T) {
 func TestValidateConfigFlagsMutuallyExclusive(t *testing.T) {
 	opts := NewOptions()
 	opts.PoolName = "config-flags-pool" // bypass the pool/selector validation
-	opts.ConfigFile = "fake-config.yaml"
+	opts.ConfigFile = testConfigFile
 	opts.ConfigText = "fake: config"
 
 	err := opts.Validate()
@@ -284,4 +292,75 @@ func TestValidateConfigFlagsMutuallyExclusive(t *testing.T) {
 			t.Errorf("Validate() error must reference the %q flag, got: %v", want, err)
 		}
 	}
+}
+
+func TestMetricsMTLSFlags(t *testing.T) {
+	fs := pflag.NewFlagSet("metrics-mtls", pflag.ContinueOnError)
+	opts := NewOptions()
+	opts.AddFlags(fs)
+	require.NoError(t, fs.Parse([]string{
+		"--pool-name", testPoolName, "--config-file", testConfigFile,
+		"--metrics-cert-dir", "/etc/epp-tls",
+		"--metrics-client-ca-file", "/etc/epp-ca/ca.crt",
+	}))
+	require.Equal(t, "/etc/epp-tls", opts.MetricsCertDir)
+	require.Equal(t, "/etc/epp-ca/ca.crt", opts.MetricsClientCAFile)
+}
+
+func TestValidateMetricsMTLS(t *testing.T) {
+	tests := []struct {
+		name         string
+		clientCA     string
+		certDir      string
+		endpointAuth bool
+		wantErr      error
+	}{
+		{name: "neither set"},
+		{name: "endpoint auth only", endpointAuth: true},
+		{name: "mTLS (cert dir + client CA)", clientCA: "ca.crt", certDir: "tls"},
+		{name: "cert dir + endpoint auth", certDir: "tls", endpointAuth: true},
+		{name: "cert dir + client CA + auth", clientCA: "ca.crt", certDir: "tls", endpointAuth: true},
+		{name: "cert dir only, no auth (fail-open)", certDir: "tls", wantErr: errMetricsTLSWithoutAuth},
+		{name: "client CA without cert dir", clientCA: "ca.crt", wantErr: errMetricsClientCARequiresCertDir},
+		{name: "client CA without cert dir, auth on", clientCA: "ca.crt", endpointAuth: true, wantErr: errMetricsClientCARequiresCertDir},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.AddFlags(pflag.NewFlagSet(tc.name, pflag.ContinueOnError))
+			opts.PoolName = testPoolName
+			opts.MetricsClientCAFile = tc.clientCA
+			opts.MetricsCertDir = tc.certDir
+			opts.MetricsEndpointAuth = tc.endpointAuth
+			err := opts.Validate()
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestCompleteMetricsCertFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := NewOptions()
+	missing.AddFlags(pflag.NewFlagSet("missing", pflag.ContinueOnError))
+	missing.MetricsCertDir = dir
+	require.ErrorIs(t, missing.Complete(), errMetricsCertUnreadable)
+
+	// tls.crt present but tls.key still missing: partial cert must fail.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.crt"), []byte("x"), 0o600))
+	partial := NewOptions()
+	partial.AddFlags(pflag.NewFlagSet("partial", pflag.ContinueOnError))
+	partial.MetricsCertDir = dir
+	require.ErrorIs(t, partial.Complete(), errMetricsCertUnreadable)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tls.key"), []byte("x"), 0o600))
+
+	present := NewOptions()
+	present.AddFlags(pflag.NewFlagSet("present", pflag.ContinueOnError))
+	present.MetricsCertDir = dir
+	require.NoError(t, present.Complete())
 }

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -76,14 +76,6 @@ const (
 	configurationFile         = "configuration-file"
 	tracingFlag               = "tracing"
 
-	// Deprecated flags
-	connector                      = "connector"
-	prefillerUseTLS                = "prefiller-use-tls"
-	decoderUseTLS                  = "decoder-use-tls"
-	encoderUseTLS                  = "UseTLSForEncoder"
-	prefillerTLSInsecureSkipVerify = "prefiller-tls-insecure-skip-verify"
-	decoderTLSInsecureSkipVerify   = "decoder-tls-insecure-skip-verify"
-
 	// Environment variables
 	envInferencePool           = "INFERENCE_POOL"
 	envEnablePrefillerSampling = "ENABLE_PREFILLER_SAMPLING"
@@ -105,32 +97,27 @@ const (
 
 // yamlConfiguration represents structure of YAML configuration for sidecar proxy
 type yamlConfiguration struct {
-	Port                           int      `json:"port,omitempty"`
-	VLLMPort                       int      `json:"vllm-port,omitempty"`
-	MooncakeBootstrapPort          int      `json:"mooncake-bootstrap-port,omitempty"`
-	P2PConnectorPort               int      `json:"p2p-connector-port,omitempty"`
-	DataParallelSize               int      `json:"data-parallel-size,omitempty"`
-	KVConnector                    string   `json:"kv-connector,omitempty"`
-	Connector                      string   `json:"connector,omitempty"`
-	ECConnector                    string   `json:"ec-connector,omitempty"`
-	EnableSSRFProtection           *bool    `json:"enable-ssrf-protection,omitempty"`
-	EnablePrefillerSampling        *bool    `json:"enable-prefiller-sampling,omitempty"`
-	EnableP2PPull                  *bool    `json:"enable-p2p-pull,omitempty"`
-	SecureServing                  *bool    `json:"secure-proxy,omitempty"`
-	CertPath                       string   `json:"cert-path,omitempty"`
-	EnableTLS                      []string `json:"enable-tls,omitempty"`
-	TLSInsecureSkipVerify          []string `json:"tls-insecure-skip-verify,omitempty"`
-	PrefillerUseTLS                *bool    `json:"prefiller-use-tls,omitempty"`
-	DecoderUseTLS                  *bool    `json:"decoder-use-tls,omitempty"`
-	PrefillerTLSInsecureSkipVerify *bool    `json:"prefiller-tls-insecure-skip-verify,omitempty"`
-	DecoderTLSInsecureSkipVerify   *bool    `json:"decoder-tls-insecure-skip-verify,omitempty"`
-	InferencePool                  string   `json:"inference-pool,omitempty"`
-	PoolGroup                      string   `json:"pool-group,omitempty"`
-	MaxIdleConnsPerHost            int      `json:"max-idle-conns-per-host,omitempty"`
-	PrefillMaxRetries              *int     `json:"prefill-max-retries,omitempty"`
-	PrefillRetryBackoff            string   `json:"prefill-retry-backoff,omitempty"`
-	DecodeChunkSize                int      `json:"decode-chunk-size,omitempty"`
-	Tracing                        *bool    `json:"tracing,omitempty"`
+	Port                    int      `json:"port,omitempty"`
+	VLLMPort                int      `json:"vllm-port,omitempty"`
+	MooncakeBootstrapPort   int      `json:"mooncake-bootstrap-port,omitempty"`
+	P2PConnectorPort        int      `json:"p2p-connector-port,omitempty"`
+	DataParallelSize        int      `json:"data-parallel-size,omitempty"`
+	KVConnector             string   `json:"kv-connector,omitempty"`
+	ECConnector             string   `json:"ec-connector,omitempty"`
+	EnableSSRFProtection    *bool    `json:"enable-ssrf-protection,omitempty"`
+	EnablePrefillerSampling *bool    `json:"enable-prefiller-sampling,omitempty"`
+	EnableP2PPull           *bool    `json:"enable-p2p-pull,omitempty"`
+	SecureServing           *bool    `json:"secure-proxy,omitempty"`
+	CertPath                string   `json:"cert-path,omitempty"`
+	EnableTLS               []string `json:"enable-tls,omitempty"`
+	TLSInsecureSkipVerify   []string `json:"tls-insecure-skip-verify,omitempty"`
+	InferencePool           string   `json:"inference-pool,omitempty"`
+	PoolGroup               string   `json:"pool-group,omitempty"`
+	MaxIdleConnsPerHost     int      `json:"max-idle-conns-per-host,omitempty"`
+	PrefillMaxRetries       *int     `json:"prefill-max-retries,omitempty"`
+	PrefillRetryBackoff     string   `json:"prefill-retry-backoff,omitempty"`
+	DecodeChunkSize         int      `json:"decode-chunk-size,omitempty"`
+	Tracing                 *bool    `json:"tracing,omitempty"`
 }
 
 // Options holds the CLI-facing configuration for the pd-sidecar proxy.
@@ -150,13 +137,6 @@ type Options struct {
 	tlsInsecureSkipVerify []string
 	// inferencePool in namespace/name or name format; used to compute Config.InferencePoolNamespace/Name in Complete().
 	inferencePool string
-
-	// Deprecated flag fields - kept for backward compatibility; migrated in Complete()
-	connector                   string // Deprecated: use --kv-connector instead
-	prefillerUseTLS             bool   // Deprecated: use --enable-tls=prefiller instead
-	decoderUseTLS               bool   // Deprecated: use --enable-tls=decoder instead
-	prefillerInsecureSkipVerify bool   // Deprecated: use --tls-insecure-skip-verify=prefiller instead
-	decoderInsecureSkipVerify   bool   // Deprecated: use --tls-insecure-skip-verify=decoder instead
 
 	loggingOptions      zap.Options // loggingOptions holds the zap logging configuration
 	pflagSet            *pflag.FlagSet
@@ -217,6 +197,7 @@ func NewOptions() *Options {
 	return &Options{
 		Config: Config{
 			Port:                    defaultPort,
+			KVConnector:             KVConnectorNIXLV2,
 			DataParallelSize:        defaultDataParallelSize,
 			SecureServing:           true,
 			EnablePrefillerSampling: enablePrefillerSampling,
@@ -246,7 +227,6 @@ func NewOptions() *Options {
 		},
 		vllmPort:      defaultVLLMPort,
 		inferencePool: os.Getenv(envInferencePool),
-		connector:     KVConnectorNIXLV2,
 	}
 }
 
@@ -326,19 +306,6 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&opts.tlsInsecureSkipVerify, tlsInsecureSkipVerify, opts.tlsInsecureSkipVerify, "stages to skip TLS verification for. Supported: "+supportedTLSStageNamesStr+". Can be specified multiple times or as comma-separated values.")
 	fs.StringVar(&opts.inferencePool, inferencePool, opts.inferencePool, "InferencePool in namespace/name or name format (e.g., default/my-pool or my-pool). A single name implies the 'default' namespace. Can also use INFERENCE_POOL env var.")
 
-	// Deprecated flags - kept for backward compatibility
-	fs.StringVar(&opts.connector, connector, opts.connector, "Deprecated: use --kv-connector instead. The P/D connector being used. Supported: "+supportedKVConnectorNamesStr)
-	_ = fs.MarkDeprecated(connector, "use --kv-connector instead")
-
-	fs.BoolVar(&opts.prefillerUseTLS, prefillerUseTLS, opts.prefillerUseTLS, "Deprecated: use --enable-tls=prefiller instead. Whether to use TLS when sending requests to prefillers.")
-	_ = fs.MarkDeprecated(prefillerUseTLS, "use --enable-tls=prefiller instead")
-	fs.BoolVar(&opts.decoderUseTLS, "decoder-use-tls", opts.decoderUseTLS, "Deprecated: use --enable-tls=decoder instead. Whether to use TLS when sending requests to the decoder.")
-	_ = fs.MarkDeprecated(decoderUseTLS, "use --enable-tls=decoder instead")
-	fs.BoolVar(&opts.prefillerInsecureSkipVerify, prefillerTLSInsecureSkipVerify, opts.prefillerInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=prefiller instead. Skip TLS verification for requests to prefiller.")
-	_ = fs.MarkDeprecated(prefillerTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=prefiller instead")
-	fs.BoolVar(&opts.decoderInsecureSkipVerify, decoderTLSInsecureSkipVerify, opts.decoderInsecureSkipVerify, "Deprecated: use --tls-insecure-skip-verify=decoder instead. Skip TLS verification for requests to decoder.")
-	_ = fs.MarkDeprecated(decoderTLSInsecureSkipVerify, "use --tls-insecure-skip-verify=decoder instead")
-
 	fs.IntVar(&opts.MaxIdleConnsPerHost, "max-idle-conns-per-host", opts.MaxIdleConnsPerHost, "max idle keep-alive connections per host for reverse proxy transports; set to at least the expected concurrency")
 	fs.IntVar(&opts.PrefillMaxRetries, prefillMaxRetries, opts.PrefillMaxRetries, "max retry attempts when a prefill request fails with a 5xx error; 0 means no retries (default)")
 	fs.DurationVar(&opts.PrefillRetryBackoff, prefillRetryBackoff, opts.PrefillRetryBackoff, "delay between prefill retry attempts")
@@ -365,11 +332,6 @@ func (opts *Options) Complete() error {
 		return err
 	}
 
-	// Migrate deprecated connector flag to KVConnector
-	if opts.connector != "" && opts.KVConnector == "" {
-		opts.KVConnector = opts.connector
-	}
-
 	// Parse inferencePool field (namespace/name or just name) into Config.
 	if opts.inferencePool != "" {
 		parts := strings.SplitN(opts.inferencePool, "/", 2)
@@ -380,20 +342,6 @@ func (opts *Options) Complete() error {
 			opts.InferencePoolNamespace = "default"
 			opts.InferencePoolName = parts[0]
 		}
-	}
-
-	// Migrate deprecated boolean TLS flags into enableTLS/tlsInsecureSkipVerify slices
-	if opts.prefillerUseTLS && !slices.Contains(opts.enableTLS, prefillStage) {
-		opts.enableTLS = append(opts.enableTLS, prefillStage)
-	}
-	if opts.decoderUseTLS && !slices.Contains(opts.enableTLS, decodeStage) {
-		opts.enableTLS = append(opts.enableTLS, decodeStage)
-	}
-	if opts.prefillerInsecureSkipVerify && !slices.Contains(opts.tlsInsecureSkipVerify, prefillStage) {
-		opts.tlsInsecureSkipVerify = append(opts.tlsInsecureSkipVerify, prefillStage)
-	}
-	if opts.decoderInsecureSkipVerify && !slices.Contains(opts.tlsInsecureSkipVerify, decodeStage) {
-		opts.tlsInsecureSkipVerify = append(opts.tlsInsecureSkipVerify, decodeStage)
 	}
 
 	// Compute Config TLS fields from stage slices
@@ -519,13 +467,6 @@ func (opts *Options) Validate() error {
 	if opts.ECConnector != "" {
 		if _, ok := supportedECConnectors[opts.ECConnector]; !ok {
 			return fmt.Errorf("--ec-connector must be one of: %s", supportedECConnectorNamesStr)
-		}
-	}
-
-	// Validate deprecated connector flag
-	if opts.connector != "" && opts.connector != opts.KVConnector {
-		if _, ok := supportedKVConnectors[opts.connector]; !ok {
-			return fmt.Errorf("--connector must be one of: %s", supportedKVConnectorNamesStr)
 		}
 	}
 
@@ -687,9 +628,6 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	if cfg.KVConnector != "" && !opts.isFlagSet(kvConnector) {
 		opts.KVConnector = cfg.KVConnector
 	}
-	if cfg.Connector != "" && !opts.isFlagSet(connector) {
-		opts.connector = cfg.Connector
-	}
 	if cfg.ECConnector != "" && !opts.isFlagSet(ecConnector) {
 		opts.ECConnector = cfg.ECConnector
 	}
@@ -716,26 +654,6 @@ func (opts *Options) mergeYAMLConfiguration(cfg yamlConfiguration) {
 	}
 	if len(cfg.TLSInsecureSkipVerify) > 0 && !opts.isFlagSet(tlsInsecureSkipVerify) {
 		opts.tlsInsecureSkipVerify = cfg.TLSInsecureSkipVerify
-	}
-
-	// update prefiller/decoder TLS settings from deprecated YAML fields if corresponding new fields are not set by user via flags
-	// (i.e., prefillerUseTLS only applies if --enable-tls and --prefiller-use-tls are not set,
-	// and decoderUseTLS only applies if --enable-tls and --decoder-use-tls are not set)
-	if cfg.PrefillerUseTLS != nil && !opts.isFlagSet(enableTLS) && !opts.isFlagSet(prefillerUseTLS) {
-		opts.prefillerUseTLS = *cfg.PrefillerUseTLS
-	}
-	if cfg.DecoderUseTLS != nil && !opts.isFlagSet(enableTLS) && !opts.isFlagSet(decoderUseTLS) {
-		opts.decoderUseTLS = *cfg.DecoderUseTLS
-	}
-
-	// update prefiller/decoder TLS insecure skip verify settings from deprecated YAML fields if corresponding new fields are not set by user via flags
-	// (i.e., prefillerTLSInsecureSkipVerify only applies if --tls-insecure-skip-verify and --prefiller-tls-insecure-skip-verify are not set,
-	// and decoderTLSInsecureSkipVerify only applies if --tls-insecure-skip-verify and --decoder-tls-insecure-skip-verify are not set)
-	if cfg.PrefillerTLSInsecureSkipVerify != nil && !opts.isFlagSet(prefillerTLSInsecureSkipVerify) && !opts.isFlagSet(tlsInsecureSkipVerify) {
-		opts.prefillerInsecureSkipVerify = *cfg.PrefillerTLSInsecureSkipVerify
-	}
-	if cfg.DecoderTLSInsecureSkipVerify != nil && !opts.isFlagSet(decoderTLSInsecureSkipVerify) && !opts.isFlagSet(tlsInsecureSkipVerify) {
-		opts.decoderInsecureSkipVerify = *cfg.DecoderTLSInsecureSkipVerify
 	}
 
 	if cfg.InferencePool != "" && !opts.isFlagSet(inferencePool) {

--- a/pkg/sidecar/proxy/options.go
+++ b/pkg/sidecar/proxy/options.go
@@ -273,7 +273,7 @@ func (opts *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&opts.P2PConnectorPort, p2pConnectorPortFlag, opts.P2PConnectorPort,
 		"the prefiller's OffloadingConnector P2P tier listening port, injected as remote_port on the decode leg (used with --kv-connector=offloading or --enable-p2p-pull)")
 	fs.BoolVar(&opts.EnableP2PPull, enableP2PPull, opts.EnableP2PPull,
-		"declare the OffloadingConnector P2P tier available for cached-prefix pulls when the PD connector is NIXL, i.e. engines run MultiConnector(NixlConnector + OffloadingConnector). No effect with --kv-connector=offloading.")
+		"declare the OffloadingConnector P2P tier available for cached-prefix pulls when the PD connector is NIXL, i.e. engines run MultiConnector(NixlConnector + OffloadingConnector). Rejected with any other --kv-connector; offloading provides the tier natively without this flag.")
 	fs.BoolVar(&opts.SecureServing, secureServing, opts.SecureServing, "Enables secure proxy. Defaults to true.")
 	fs.StringVar(&opts.CertPath, certPath, opts.CertPath, "The path to the certificate for secure proxy. The certificate and private key files are assumed to be named tls.crt and tls.key, respectively. If not set, and secureProxy is enabled, then a self-signed certificate is used (for testing).")
 	fs.BoolVar(&opts.EnableSSRFProtection, enableSSRFProtection, opts.EnableSSRFProtection, "enable SSRF protection using InferencePool allowlisting")

--- a/pkg/sidecar/proxy/options_test.go
+++ b/pkg/sidecar/proxy/options_test.go
@@ -46,7 +46,6 @@ port: 8100
 vllm-port: 8001
 data-parallel-size: 5
 kv-connector: %q
-connector: %q
 ec-connector: %q
 enable-ssrf-protection: true
 enable-prefiller-sampling: true
@@ -54,10 +53,8 @@ enable-p2p-pull: true
 enable-tls:
 - prefiller
 - decoder
-prefiller-use-tls: false
 tls-insecure-skip-verify:
 - prefiller
-decoder-tls-insecure-skip-verify: true
 secure-proxy: false
 cert-path: "/etc/certificates-file"
 inference-pool: "file-ns/inference-pool-file"
@@ -68,7 +65,7 @@ prefill-retry-backoff: "500ms"
 decode-chunk-size: 128
 mooncake-bootstrap-port: 9000
 tracing: true
-`, KVConnectorNIXLV2, KVConnectorSGLang, ECExampleConnector))
+`, KVConnectorNIXLV2, ECExampleConnector))
 }
 
 func createConfigWithUnknownKeys(t *testing.T) string {
@@ -95,16 +92,12 @@ func TestSidecarConfiguration(t *testing.T) {
 		vllm-port: 8021,
 		data-parallel-size: 3,
 		kv-connector: %s,
-		connector: %s,
 		ec-connector: %s,
 		enable-ssrf-protection: true,
 		enable-prefiller-sampling: true,
 		enable-p2p-pull: true,
 		enable-tls: ['prefiller', 'decoder'],
-		prefiller-use-tls: false,
-		decoder-use-tls: true,
 		tls-insecure-skip-verify: ['decoder'],
-		prefiller-tls-insecure-skip-verify: true,
 		secure-proxy: false,
 		cert-path: '/etc/certificates-inline',
 		inference-pool: inline-ns/inference-pool-inline,
@@ -115,7 +108,7 @@ func TestSidecarConfiguration(t *testing.T) {
 		decode-chunk-size: 256,
 		mooncake-bootstrap-port: 9001,
 		tracing: true
-	}`, KVConnectorNIXLV2, KVConnectorSGLang, ECExampleConnector)
+	}`, KVConnectorNIXLV2, ECExampleConnector)
 	invalidInlineYAML := "{port: 8200, invalid-yaml}"
 
 	// -- file YAML for testing ---
@@ -143,7 +136,6 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.MooncakeBootstrapPort = 9001
 
 				o.KVConnector = KVConnectorNIXLV2
-				o.connector = KVConnectorSGLang
 				o.ECConnector = ECExampleConnector
 
 				o.EnableSSRFProtection = true
@@ -155,8 +147,8 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.UseTLSForDecoder = true
 				o.UseTLSForEncoder = false
 
-				o.tlsInsecureSkipVerify = []string{prefillStage, decodeStage}
-				o.InsecureSkipVerifyForPrefiller = true
+				o.tlsInsecureSkipVerify = []string{decodeStage}
+				o.InsecureSkipVerifyForPrefiller = false
 				o.InsecureSkipVerifyForDecoder = true
 				o.InsecureSkipVerifyForEncoder = false
 
@@ -203,9 +195,9 @@ func TestSidecarConfiguration(t *testing.T) {
 				o.UseTLSForDecoder = true
 				o.UseTLSForEncoder = false
 
-				o.tlsInsecureSkipVerify = []string{prefillStage, decodeStage}
+				o.tlsInsecureSkipVerify = []string{prefillStage}
 				o.InsecureSkipVerifyForPrefiller = true
-				o.InsecureSkipVerifyForDecoder = true
+				o.InsecureSkipVerifyForDecoder = false
 				o.InsecureSkipVerifyForEncoder = false
 
 				o.SecureServing = false
@@ -295,7 +287,6 @@ func TestSidecarConfiguration(t *testing.T) {
 				ecConnector: ECConnectorNIXL,
 			},
 			expected: func(o *Options) {
-				// Complete() migrates the default connector (KVConnectorNIXLV2) into KVConnector.
 				o.KVConnector = KVConnectorNIXLV2
 				o.ECConnector = ECConnectorNIXL
 			},
@@ -386,6 +377,13 @@ func TestSidecarConfiguration(t *testing.T) {
 			expectedError: errors.New("failed to unmarshal sidecar configuration"),
 		},
 		{
+			name: "removed connector key in YAML is rejected",
+			inputFlags: map[string]any{
+				inlineConfiguration: "{port: 8011, connector: nixlv2}",
+			},
+			expectedError: errors.New("failed to unmarshal sidecar configuration"),
+		},
+		{
 			name: "both inline and file YAML",
 			inputFlags: map[string]any{
 				inlineConfiguration: inlineYAML,
@@ -466,12 +464,12 @@ func compareOptions(t *testing.T, expected, actual *Options) {
 	assertEqual(enablePrefillerSampling, expected.EnablePrefillerSampling, actual.EnablePrefillerSampling)
 	assertEqual(enableP2PPull, expected.EnableP2PPull, actual.EnableP2PPull)
 
-	assertEqual(prefillerUseTLS, expected.UseTLSForPrefiller, actual.UseTLSForPrefiller)
-	assertEqual(decoderUseTLS, expected.UseTLSForDecoder, actual.UseTLSForDecoder)
-	assertEqual(encoderUseTLS, expected.UseTLSForEncoder, actual.UseTLSForEncoder)
+	assertEqual("UseTLSForPrefiller", expected.UseTLSForPrefiller, actual.UseTLSForPrefiller)
+	assertEqual("UseTLSForDecoder", expected.UseTLSForDecoder, actual.UseTLSForDecoder)
+	assertEqual("UseTLSForEncoder", expected.UseTLSForEncoder, actual.UseTLSForEncoder)
 
-	assertEqual(prefillerTLSInsecureSkipVerify, expected.InsecureSkipVerifyForPrefiller, actual.InsecureSkipVerifyForPrefiller)
-	assertEqual(decoderTLSInsecureSkipVerify, expected.InsecureSkipVerifyForDecoder, actual.InsecureSkipVerifyForDecoder)
+	assertEqual("InsecureSkipVerifyForPrefiller", expected.InsecureSkipVerifyForPrefiller, actual.InsecureSkipVerifyForPrefiller)
+	assertEqual("InsecureSkipVerifyForDecoder", expected.InsecureSkipVerifyForDecoder, actual.InsecureSkipVerifyForDecoder)
 	assertEqual("InsecureSkipVerifyForEncoder", expected.InsecureSkipVerifyForEncoder, actual.InsecureSkipVerifyForEncoder)
 
 	assertSlice(enableTLS, expected.enableTLS, actual.enableTLS)
@@ -688,7 +686,7 @@ func TestValidateConnector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := NewOptions()
-			opts.connector = tt.connector
+			opts.KVConnector = tt.connector
 			_ = opts.Complete() // Complete must be called before Validate
 			err := opts.Validate()
 			if (err != nil) != tt.wantErr {
@@ -1024,10 +1022,6 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 		name                         string
 		enableTLS                    []string
 		tlsInsecureSkipVerify        []string
-		deprecatedPrefillerUseTLS    bool
-		deprecatedDecoderUseTLS      bool
-		deprecatedPrefillerInsecure  bool
-		deprecatedDecoderInsecure    bool
 		vllmPort                     string
 		expectedDecoderURL           string
 		expectedUseTLSForPrefiller   bool
@@ -1090,34 +1084,6 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			expectedInsecureForPrefiller: true,
 			expectedInsecureForDecoder:   true,
 		},
-		{
-			name:                         "deprecated flags migration",
-			enableTLS:                    []string{},
-			tlsInsecureSkipVerify:        []string{},
-			deprecatedPrefillerUseTLS:    true,
-			deprecatedDecoderUseTLS:      true,
-			deprecatedPrefillerInsecure:  true,
-			deprecatedDecoderInsecure:    true,
-			vllmPort:                     "8001",
-			expectedDecoderURL:           "https://localhost:8001",
-			expectedUseTLSForPrefiller:   true,
-			expectedUseTLSForDecoder:     true,
-			expectedInsecureForPrefiller: true,
-			expectedInsecureForDecoder:   true,
-		},
-		{
-			name:                         "mixed deprecated and new flags",
-			enableTLS:                    []string{"prefiller"},
-			tlsInsecureSkipVerify:        []string{},
-			deprecatedDecoderUseTLS:      true,
-			deprecatedDecoderInsecure:    true,
-			vllmPort:                     "8001",
-			expectedDecoderURL:           "https://localhost:8001",
-			expectedUseTLSForPrefiller:   true,
-			expectedUseTLSForDecoder:     true,
-			expectedInsecureForPrefiller: false,
-			expectedInsecureForDecoder:   true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -1125,10 +1091,6 @@ func TestCompleteTLSConfiguration(t *testing.T) {
 			opts := NewOptions()
 			opts.enableTLS = tt.enableTLS
 			opts.tlsInsecureSkipVerify = tt.tlsInsecureSkipVerify
-			opts.prefillerUseTLS = tt.deprecatedPrefillerUseTLS
-			opts.decoderUseTLS = tt.deprecatedDecoderUseTLS
-			opts.prefillerInsecureSkipVerify = tt.deprecatedPrefillerInsecure
-			opts.decoderInsecureSkipVerify = tt.deprecatedDecoderInsecure
 			opts.vllmPort = tt.vllmPort
 
 			err := opts.Complete()

--- a/release-notes.d/unreleased/1831.md
+++ b/release-notes.d/unreleased/1831.md
@@ -1,0 +1,7 @@
+---
+pr: 1831
+url: https://github.com/llm-d/llm-d-router/pull/1831
+author: LukeAVanDrie
+date: 2026-07-15
+---
+flowcontrol: the OrderingPolicy plugin interface no longer includes RequiredQueueCapabilities(); ordering policies only implement Less(). The QueueCapability system and the FCFS-only ListQueue are removed - all flows use the priority queue, so FCFS now dispatches in exact logical-arrival order.

--- a/release-notes.d/unreleased/1858.md
+++ b/release-notes.d/unreleased/1858.md
@@ -1,0 +1,7 @@
+---
+pr: 1858
+url: https://github.com/llm-d/llm-d-router/pull/1858
+author: hexfusion
+date: 2026-07-16
+---
+metrics/models data sources: add optional `caCertPath`, `clientCertPath`, and `clientKeyPath` to verify the scrape target's server certificate against a CA bundle and present a client certificate for mTLS.

--- a/release-notes.d/unreleased/1919.md
+++ b/release-notes.d/unreleased/1919.md
@@ -1,0 +1,7 @@
+---
+pr: 1919
+url: https://github.com/llm-d/llm-d-router/pull/1919
+author: hexfusion
+date: 2026-07-16
+---
+EPP: the metrics endpoint can now be served over mTLS via `--metrics-cert-dir` (server cert) and `--metrics-client-ca-file` (client CA).

--- a/release-notes.d/unreleased/1937.md
+++ b/release-notes.d/unreleased/1937.md
@@ -1,0 +1,7 @@
+---
+pr: 1937
+url: https://github.com/llm-d/llm-d-router/pull/1937
+author: nilig
+date: 2026-07-14
+---
+The routing sidecar honors the `x-kv-cache-source-host-port` header, injecting `kv_transfer_params.p2p` so vLLM pulls cached prefix KV from the named peer over the OffloadingConnector P2P tier instead of recomputing it.

--- a/release-notes.d/unreleased/2034.md
+++ b/release-notes.d/unreleased/2034.md
@@ -1,0 +1,7 @@
+---
+pr: 2034
+url: https://github.com/llm-d/llm-d-router/pull/2034
+author: Madhumasa84
+date: 2026-07-16
+---
+Document flow_control_requests_total flow control metric in docs/metrics.md.

--- a/test/integration/epp/runtime_polling_test.go
+++ b/test/integration/epp/runtime_polling_test.go
@@ -86,7 +86,7 @@ func TestRuntimePollingDispatch(t *testing.T) {
 			r := datalayer.NewRuntime(pollingInterval)
 			ext := mocks.NewPollingExtractor("test-extractor")
 
-			httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+			httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 				parsePrometheusMetrics)
 			require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestRuntimePollingMultipleExtractors(t *testing.T) {
 	ext1 := mocks.NewPollingExtractor("extractor-1")
 	ext2 := mocks.NewPollingExtractor("extractor-2")
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 
@@ -187,7 +187,7 @@ func TestRuntimePollingEndpointLifecycle(t *testing.T) {
 	r := datalayer.NewRuntime(pollingInterval)
 	ext := mocks.NewPollingExtractor("lifecycle-extractor")
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 
@@ -241,7 +241,7 @@ func TestRuntimePollingWithoutExtractors(t *testing.T) {
 
 	r := datalayer.NewRuntime(50 * time.Millisecond)
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 
@@ -280,7 +280,7 @@ func TestRuntimePollingHTTPError(t *testing.T) {
 	r := datalayer.NewRuntime(pollingInterval)
 	ext := mocks.NewPollingExtractor("error-extractor")
 
-	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", true, "test-http", "test-source",
+	httpSrc, err := httpds.NewHTTPDataSource("http", "/metrics", httpds.TLSOptions{SkipVerify: true}, "test-http", "test-source",
 		parsePrometheusMetrics)
 	require.NoError(t, err)
 

--- a/test/perf/config/router-configs/optimized-baseline.yaml
+++ b/test/perf/config/router-configs/optimized-baseline.yaml
@@ -11,7 +11,7 @@ router:
     replicas: 1
     image:
       registry: ghcr.io/llm-d
-      repository: llm-d-router-endpoint-picker-dev
+      repository: llm-d-router-endpoint-picker
       tag: main
       pullPolicy: Always
     flags:

--- a/test/perf/run_nightly_perf.py
+++ b/test/perf/run_nightly_perf.py
@@ -118,7 +118,7 @@ def deploy_epp(ns, chart_path, chart_version, router_config_path, epp_cpu="2", e
     release_name = os.path.splitext(os.path.basename(router_config_path))[0]
     
     epp_registry = os.environ.get("EPP_REGISTRY", "ghcr.io/llm-d")
-    epp_repository = os.environ.get("EPP_REPOSITORY", "llm-d-router-endpoint-picker-dev")
+    epp_repository = os.environ.get("EPP_REPOSITORY", "llm-d-router-endpoint-picker")
     epp_tag = os.environ.get("EPP_TAG", "main")
     
     cpu_limit = double_cpu(epp_cpu)
@@ -657,7 +657,7 @@ def main():
     # Resolve relative defaults
     default_sim_deploy = os.path.join(script_dir, "config", "llm-d-sim-deployment.yaml")
     default_sim_svc = os.path.join(script_dir, "config", "llm-d-sim-service.yaml")
-    default_router_chart = "oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev"
+    default_router_chart = "oci://ghcr.io/llm-d/charts/llm-d-router-standalone"
     default_perf_chart = os.path.abspath(os.path.join(script_dir, "..", "..", "..", "..", "inference-perf", "deploy", "inference-perf"))
     default_perf_job = os.path.join(script_dir, "config", "shared_prefix_job1.yaml")
     default_results_dir = os.path.abspath(os.path.join(script_dir, "results"))


### PR DESCRIPTION
Syncs llm-d/llm-d-router main into opendatahub-io/llm-d-router main.

Upstream commit: https://github.com/llm-d/llm-d-router/commit/c82561bfd05902c93b55998e9ee9a410977c0d07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added endpoint-attribute filtering based on configurable thresholds, missing-attribute handling, and fallback behavior.
  - Added optional image tags for CI builds.
  - Added CA certificate and mutual TLS support for data sources and metrics endpoints.
  - Added request-header processing, model-name rewriting, and improved fairness identity handling.
  - Added bounded diagnostic state reporting for fairness and caching components.
  - Added flow-control request outcome metrics.

- **Bug Fixes**
  - Improved CI status aggregation for matrix-based end-to-end checks.
  - Corrected prefix matching behavior when both matching limits are zero.

- **Documentation**
  - Updated configuration guidance, image defaults, TLS options, metrics, and plugin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->