### PR TITLE
chore: add madhugoutham to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,7 @@ aliases:
   - Gregory-Pereira
   - hexfusion
   - kylape
+  - madhugoutham
   - nainaz
   - RishabhSaini
   - tessapham


### PR DESCRIPTION
Add madhugoutham to llm-d-team OWNERS_ALIASES for review permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new ownership alias for `madhugoutham`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->